### PR TITLE
Spelling

### DIFF
--- a/wireless_tools/CHANGELOG.h
+++ b/wireless_tools/CHANGELOG.h
@@ -280,7 +280,7 @@
  *		(From Pavel Roskin <proski@gnu.org>)
  *	o Make $(DYNAMIC_LINK) relative (and not absolute) [Makefile]
  *	---
- *	o Replace all float occurence with double [iwlib, iwlist]
+ *	o Replace all float occurrence with double [iwlib, iwlist]
  *	o Implement iwgetid --mode [iwgetid]
  *	o Convert frequency to channel [iwlist, iwlib]
  *		(Suggested by Pavel Roskin <proski@gnu.org> - always him !)
@@ -308,7 +308,7 @@
  * wireless 26 :
  * -----------
  *	o #define IFLA_WIRELESS if needed [iwlib]
- *	o Update man page with SuSE intruction (see below) [wireless.7]
+ *	o Update man page with SuSE instruction (see below) [wireless.7]
  *		(From Alexander Pevzner <pzz@pzz.msk.ru>)
  *	o Allow to display all 8 bit rates instead of 7 [iwlist]
  *	o Fix retry lifetime to not set IW_RETRY_LIMIT flag [iwconfig]
@@ -372,7 +372,7 @@
  * -----------
  *	o Add 'sed' magic to automatically get WT/WE versions [Makefile]
  *	o Change soname of iwlib to libiwWE.so.WT [Makefile]
- *		Now dynamicaly linked versioned install can work
+ *		Now dynamically linked versioned install can work
  *	o Default to dynamic build, don't build static lib [Makefile]
  *	o Update installation instructions [INSTALL]
  *	o fflush(stdout), so that redirect to file/pipe works [iwevent]
@@ -428,7 +428,7 @@
  *	o Accept arbitrary number of private definitions [iwlib/iwpriv]
  *	---
  *	o Added Hotplug documentation [HOTPLUG.txt]
- *	o Add dependancies (gcc way), remove makedepend [Makefile]
+ *	o Add dependencies (gcc way), remove makedepend [Makefile]
  *		(From Maxime Charpenne <maxime.charpenne@free.fr>)
  *	o Traduction en francais des pages manuel [fr/*]
  *	o Fix some incorrect/ambiguous sentences [iwconfig.8/iwevent.8]
@@ -681,7 +681,7 @@
  *		(From Dima Ryazanov <someone@berkeley.edu>)
  *	o Fix iw_scan()/iw_process_scan() for non-root -> EPERM [iwlib]
  *		(Bug reported by Arkadiusz Miskiewicz <arekm@pld-linux.org>)
- *	o Fix "iwconfig nickname" (was abreviated) [iwconfig]
+ *	o Fix "iwconfig nickname" (was abbreviated) [iwconfig]
  *		(Bug reported by Charles Plessy)
  *	o Invalid mode from driver segfault iwlist scan [iwlist]
  *		(From Aurelien Jacobs <aurel@gnuage.org>)

--- a/wireless_tools/CHANGELOG.h
+++ b/wireless_tools/CHANGELOG.h
@@ -738,7 +738,7 @@
  *		(Bug reported by Johan Danielsson <joda11147@gmail.com>)
  *	o Fix OUI type check for WPA 1 IE [iwlist.c]
  *	---
- *		(Bug reported by Florent Daignière)
+ *		(Bug reported by Florent DaigniÃ¨re)
  *	o Don't look for "fixed" out of array in set_txpower_info() [iwconfig]
  */
 

--- a/wireless_tools/DISTRIBUTIONS.txt
+++ b/wireless_tools/DISTRIBUTIONS.txt
@@ -30,7 +30,7 @@ distribution, please use the PCMCIA method).
 
 	Please remember : I don't use your distribution, and I have
 absolutely no clue about how your distribution works. I'm just
-collecting random information here without beeing able to verify it.
+collecting random information here without being able to verify it.
 
 				-----
 
@@ -200,7 +200,7 @@ PCMCIA, USB, etc. The files network.opts and wireless.opts in
 /etc/pcmcia are not used any longer. There is /sbin/ifup to set up all
 kind of network interface.
 	There is a file /etc/sysconfig/network/wireless where you may
-set most of the options of iwconfig in seperate variables (they are
+set most of the options of iwconfig in separate variables (they are
 named like the options). Additionally you may use
 WIRELESS_IWCONFIG_OPTIONS e.g. for setting key 2, 3 or 4 or
 unsupported iwconfig commands. This file is documented and its
@@ -282,7 +282,7 @@ configuration file have change to include the WIRELESS_ prefix :
 		WIRELESS_ESSID='<essid>'
 		WIRELESS_ENC_KEY='<key>'
 	The underlying configuration files and configurations options
-seems to be indentical to what is done in Mandrake 8.2 (or vice
+seems to be identical to what is done in Mandrake 8.2 (or vice
 versa), so please check the section below. This allow configuration of
 additional wireless settings not available in the GUI.
 

--- a/wireless_tools/HOTPLUG.txt
+++ b/wireless_tools/HOTPLUG.txt
@@ -593,7 +593,7 @@ you should find a section in /etc/hotplug/net.agent looking like the
 patch above. Otherwise, just cut'n'paste the patch above in the right
 place.
 	The path for 'ifrename' is used twice above, so don't forget
-to modify both occurences.
+to modify both occurrences.
 
 
 	9) Loading driver modules

--- a/wireless_tools/IFRENAME-VS-XXX.txt
+++ b/wireless_tools/IFRENAME-VS-XXX.txt
@@ -102,7 +102,7 @@ hotplug. 'udev' can't deal with those devices.
 		o It is common practice on embedded system to use a
 static /dev and not 'udev' to save space and boot time. And to not use
 hotplug for the same reasons.
-		o 'ifrename' has now a udev compatiblity mode that
+		o 'ifrename' has now a udev compatibility mode that
 enables to trivially integrate it into 'udev' as an IMPORT rule. This
 requires udev version 107 or better and ifrename 29-pre17 or better.
 

--- a/wireless_tools/Makefile
+++ b/wireless_tools/Makefile
@@ -170,7 +170,7 @@ install-static:: $(STATIC)
 	install -m 755 -d $(INSTALL_LIB)
 	install -m 644 $(STATIC) $(INSTALL_LIB)
 
-# All the binaries. Careful, no dependancy on install-dynamic
+# All the binaries. Careful, no dependency on install-dynamic
 install-bin:: all
 	install -m 755 -d $(INSTALL_DIR)
 	install -m 755 $(PROGS) $(INSTALL_DIR)
@@ -225,5 +225,5 @@ uninstall::
 	  $(RM) $(INSTALL_MAN)/man5/$$f; \
 	done
 
-# Include dependancies
+# Include dependencies
 -include *.d

--- a/wireless_tools/README
+++ b/wireless_tools/README
@@ -67,7 +67,7 @@ read locally with the command :
 localised man pages (fr/*)
 -------------------
 	Localised man pages are not made by me, therefore the only
-localisations available are those sent to me by courageous volonteers,
+localisations available are those sent to me by courageous volunteers,
 and I expect those man pages to 'lag' compared to the english
 version (i.e. not have all the latest updates). Translating man pages
 is not a very gratifying task, especially due to my broken english,

--- a/wireless_tools/README.fr
+++ b/wireless_tools/README.fr
@@ -1,10 +1,10 @@
 	Wireless Tools
 	--------------
 
-	Ce paquetage contient les Wireless Tools (Outils Wireless), utilisé pour
+	Ce paquetage contient les Wireless Tools (Outils Wireless), utilisÃ© pour
 manipuler les Wireless Extensions. Les Wireless Extensions sont une interface
-vous permettant de manier les paramètres spécifiques aux Wireless LAN (réseaux
-sans fil) et d'obtenir les statistiques spécifiques.
+vous permettant de manier les paramÃ¨tres spÃ©cifiques aux Wireless LAN (rÃ©seaux
+sans fil) et d'obtenir les statistiques spÃ©cifiques.
 
 page web :
 --------
@@ -12,112 +12,112 @@ page web :
 		http://www.hpl.hp.com/personal/Jean_Tourrilhes/Linux/Tools.html
 		http://web.hpl.hp.com/personal/Jean_Tourrilhes/Linux/
 
-version pré compilée
+version prÃ© compilÃ©e
 --------------------
-	La plupart des distributions Linux fournit un paquetage pré compilé
-contenant ces outils. Et beaucoup d'entre elles les pré installent par défaut.
+	La plupart des distributions Linux fournit un paquetage prÃ© compilÃ©
+contenant ces outils. Et beaucoup d'entre elles les prÃ© installent par dÃ©faut.
 Par ailleurs, l'installation de ce paquetage est (maintenant) facile et vous
-permet d'obtenir une version plus à jour.
+permet d'obtenir une version plus Ã  jour.
 
 INSTALL
 -------
 	Ce fichier contient les instructions et les requis pour l'installation.
-	*Doit* être lu.
+	*Doit* Ãªtre lu.
 
 DISTRIBUTION.txt
 ----------------
-	Ce fichier documente la manière de configurer les cartes wireless au
-démarrage avec différentes distributions Linux (en utilisant les Wireless
+	Ce fichier documente la maniÃ¨re de configurer les cartes wireless au
+dÃ©marrage avec diffÃ©rentes distributions Linux (en utilisant les Wireless
 Extensions). Veuillez le lire attentivement avant de poser des questions.
-	Dans ce fichier, j'essaye de rassembler toutes les spécificités de
-l'intégration des Wireless Extensions dans les ditributions Linux les plus
-courantes. J'ai besoin de votre aide pour compléter ce fichier.
+	Dans ce fichier, j'essaye de rassembler toutes les spÃ©cificitÃ©s de
+l'intÃ©gration des Wireless Extensions dans les ditributions Linux les plus
+courantes. J'ai besoin de votre aide pour complÃ©ter ce fichier.
 
 HOTPLUG.txt
 -----------
-	Ce fichier documente la manière de gérer et configurer les cartes
-wireless éjectables utilisant Hotplug. Il est plus avancé que les simples
-procédures de DISTRIBUTIONS.txt. Pour l'instant, il est principalement orienté
-Debian, mais j'espère que vous contribuerez pour d'autres distributions.
+	Ce fichier documente la maniÃ¨re de gÃ©rer et configurer les cartes
+wireless Ã©jectables utilisant Hotplug. Il est plus avancÃ© que les simples
+procÃ©dures de DISTRIBUTIONS.txt. Pour l'instant, il est principalement orientÃ©
+Debian, mais j'espÃ¨re que vous contribuerez pour d'autres distributions.
 
 PCMCIA.txt
 ----------
-	Ce fichier décrit comment utiliser le script init PCMCIA pour configurer
-les Wireless Extensions et comment utiliser les schemes PCMCIA (NDT : procédures
+	Ce fichier dÃ©crit comment utiliser le script init PCMCIA pour configurer
+les Wireless Extensions et comment utiliser les schemes PCMCIA (NDT : procÃ©dures
 automatiques).
 
 pages man (iwconfig.8, iwlist.8, iwpriv.8, iwspy.8)
 ---------
-	TRÈS IMPORTANT : J'essaye de garder les pages man à jour, ainsi vous
+	TRÃˆS IMPORTANT : J'essaye de garder les pages man Ã  jour, ainsi vous
 devriez les lire avant de poser des questions.
-	TRÈS IMPORTANT : Ces pages man décrivent les fonctionnalités des outils,
-pas un périphérique n'en implémente toute l'étendue (et les pilotes en
-implémentent souvent encore moins).
+	TRÃˆS IMPORTANT : Ces pages man dÃ©crivent les fonctionnalitÃ©s des outils,
+pas un pÃ©riphÃ©rique n'en implÃ©mente toute l'Ã©tendue (et les pilotes en
+implÃ©mentent souvent encore moins).
 
-	Pour autant que je sache, les pages man constituent la plus complète, la
-plus à jour et la plus précise des documentations des Wireless Tools. Une mise
-à jour de la page web concernant les Wireless Extensions a été faite il y a fort
+	Pour autant que je sache, les pages man constituent la plus complÃ¨te, la
+plus Ã  jour et la plus prÃ©cise des documentations des Wireless Tools. Une mise
+Ã  jour de la page web concernant les Wireless Extensions a Ã©tÃ© faite il y a fort
 longtemps. Envoyez-moi vos retours.
 
-	Les pages man peuvent aussi bien être copiées dans un endroit où la
-commande « man » les trouvera, comme /usr/local/man/man8, ou peut être lue
+	Les pages man peuvent aussi bien Ãªtre copiÃ©es dans un endroit oÃ¹ la
+commande Â« man Â» les trouvera, comme /usr/local/man/man8, ou peut Ãªtre lue
 localement avec la commande :
 		nroff -man xxx.8 | less
-(NDT : ou plus simplement avec « man ./xxx.8 »)
+(NDT : ou plus simplement avec Â« man ./xxx.8 Â»)
 
-pages man localisées (fr/*)
+pages man localisÃ©es (fr/*)
 --------------------
-	Les pages de man localisées ne sont pas écrites par moi (NDT\ : ainsi
-que ce document), par conséquent les seules disponibles sont celles qui me sont
-envoyées par de courageux volontaires et il faut s'attendre à ce que ces pages
-man soient en décalage par rapport à la version anglaise (c.-à-d. qu'elles
-n'aient pas toutes les mises à jour). La traduction des pages man n'est pas une
-tâche très gratifiante, sans compter mon anglais bancal et un certain nombre
+	Les pages de man localisÃ©es ne sont pas Ã©crites par moi (NDT\ : ainsi
+que ce document), par consÃ©quent les seules disponibles sont celles qui me sont
+envoyÃ©es par de courageux volontaires et il faut s'attendre Ã  ce que ces pages
+man soient en dÃ©calage par rapport Ã  la version anglaise (c.-Ã -d. qu'elles
+n'aient pas toutes les mises Ã  jour). La traduction des pages man n'est pas une
+tÃ¢che trÃ¨s gratifiante, sans compter mon anglais bancal et un certain nombre
 de termes techniques difficilement traduisibles vers d'autres langues, donc
-référez-vous à la version anglaise en cas de doute.
+rÃ©fÃ©rez-vous Ã  la version anglaise en cas de doute.
 
 iwconfig.c
 ----------
-	L'outil wireless principal. Utilisé pour la configuration du matériel et
-pour voir les paramètres wireless les plus communs.
+	L'outil wireless principal. UtilisÃ© pour la configuration du matÃ©riel et
+pour voir les paramÃ¨tres wireless les plus communs.
 
 iwlist.c
 --------
-	Affiche une grosse quantité d'information qui ne l'est pas par iwconfig.
-	Par exemple, tous les débits, toutes les fréquences, toutes les clefs...
+	Affiche une grosse quantitÃ© d'information qui ne l'est pas par iwconfig.
+	Par exemple, tous les dÃ©bits, toutes les frÃ©quences, toutes les clefs...
 
 iwspy.c
 -------
-	Test de support Mobile IP et autorise la récupération de statistiques
+	Test de support Mobile IP et autorise la rÃ©cupÃ©ration de statistiques
 par adresse MAC (au lieu des stats globales). Aussi, pour certains
-pilotes/périphériques, c'est la seule manière d'obtenir des stats en mode
+pilotes/pÃ©riphÃ©riques, c'est la seule maniÃ¨re d'obtenir des stats en mode
 Ad-Hoc.
 
 iwpriv.c
 --------
-	Manipule les ioctls privées des pilotes (« driver private ioctls ») :
-tous les paramètres qui sont spécifiques à un pilote ou à un périphérique et
-qui, par conséquent, ne font pas partie de iwconfig.
+	Manipule les ioctls privÃ©es des pilotes (Â« driver private ioctls Â») :
+tous les paramÃ¨tres qui sont spÃ©cifiques Ã  un pilote ou Ã  un pÃ©riphÃ©rique et
+qui, par consÃ©quent, ne font pas partie de iwconfig.
 
 iwgetid.c
 ---------
-	Affiche l'ESSID ou le NWID du périphérique spécifié.
-	Peut aussi l'afficher dans un format pouvant être utilisé comme un
-« PCMCIA Scheme ».
+	Affiche l'ESSID ou le NWID du pÃ©riphÃ©rique spÃ©cifiÃ©.
+	Peut aussi l'afficher dans un format pouvant Ãªtre utilisÃ© comme un
+Â« PCMCIA Scheme Â».
 
 iwevent.c
 ---------
-	Affiche les « Wireless Events » (Événements Wireless). Cela est
+	Affiche les Â« Wireless Events Â» (Ã‰vÃ©nements Wireless). Cela est
 nouveau, il n'y a donc pas encore beaucoup de pilotes qui le supportent...
 
 ifrename.c :
 ----------
-	Renomme les interfaces réseau basées sur différents attributs.
+	Renomme les interfaces rÃ©seau basÃ©es sur diffÃ©rents attributs.
 
 iwlib.c
 -------
-	Les librairies « helper » Wireless Tools. Peuvent être utiles si vous
-voulez créer votre propre application en utilisant les Wireless Extensions.
+	Les librairies Â« helper Â» Wireless Tools. Peuvent Ãªtre utiles si vous
+voulez crÃ©er votre propre application en utilisant les Wireless Extensions.
 
 Changelog, contributions :
 ------------------------
@@ -125,26 +125,26 @@ Changelog, contributions :
 
 wireless.h
 ----------
-	Définition des Wireless Extensions. Gardez à l'esprit que la définition
-utilisée par les pilotes et les outils (Wireless Tools) doivent correspondre,
-sinon de drôles de choses peuvent arriver. Les outils essayent de le vérifier.
+	DÃ©finition des Wireless Extensions. Gardez Ã  l'esprit que la dÃ©finition
+utilisÃ©e par les pilotes et les outils (Wireless Tools) doivent correspondre,
+sinon de drÃ´les de choses peuvent arriver. Les outils essayent de le vÃ©rifier.
 	Depuis les Wireless Extensions v12, vous ne pouvez plus mettre ce
-fichier dans les entêtes de votre noyau pour mettre à jour les Wireless
+fichier dans les entÃªtes de votre noyau pour mettre Ã  jour les Wireless
 Extensions, vous avez besoin d'utiliser les patches complets disponibles sur ma
-page web. Donc, son utilité est plus pour le cas où vous prévoyez de faire de
-la compilation transverse (if you plan to do some « cross compile ») ou quelque
+page web. Donc, son utilitÃ© est plus pour le cas oÃ¹ vous prÃ©voyez de faire de
+la compilation transverse (if you plan to do some Â« cross compile Â») ou quelque
 chose de similaire.
-Juste pour votre plaisir, il y en a différentes versions. Si vos noyau/pilotes
-sont anciens, vous voudrez peut-être essayer les anciennes versions...
+Juste pour votre plaisir, il y en a diffÃ©rentes versions. Si vos noyau/pilotes
+sont anciens, vous voudrez peut-Ãªtre essayer les anciennes versions...
 
 sample_xxx.c :
 ------------
-	Différents échantillons de code montrant comment implémenter quelques
-unes des caractéristiques les plus intéressantes des Wireless Extensions dans
+	DiffÃ©rents Ã©chantillons de code montrant comment implÃ©menter quelques
+unes des caractÃ©ristiques les plus intÃ©ressantes des Wireless Extensions dans
 votre pilote.
 	Notez qu'il n'y a pas d'assurance que ce code compile, laissez-le tel
 quel, mais cela devrait vous orienter dans la bonne direction.
-	Aussi, jetez un ½il aux pilotes existant dans le noyau Linux.
+	Aussi, jetez un Â½il aux pilotes existant dans le noyau Linux.
 
 Autres outils :
 -------------
@@ -154,8 +154,8 @@ Extensions que vous pourriez trouver utiles...
 
 Autres questions :
 ----------------
-	Vous avez le source, et il est documenté. Dans 99% des cas, vous y
-trouverez votre réponse.
+	Vous avez le source, et il est documentÃ©. Dans 99% des cas, vous y
+trouverez votre rÃ©ponse.
 
 	Bonne chance...
 

--- a/wireless_tools/cs/ifrename.8
+++ b/wireless_tools/cs/ifrename.8
@@ -1,12 +1,12 @@
 .\" Jean II - HPL - 2004
 .\" ifrename.8
 .\"
-.TH IFRENAME 8 "1.bøezen 2004" "wireless-tools" "Linux - Manuál programátora"
+.TH IFRENAME 8 "1.bÅ™ezen 2004" "wireless-tools" "Linux - ManuÃ¡l programÃ¡tora"
 .\"
 .\" NAME part
 .\"
-.SH JMÉNO
-ifrename \- Pøejmenuje sí»ová rozhraní v závislosti na rùznıch statickıch kritériích
+.SH JMÃ‰NO
+ifrename \- PÅ™ejmenuje sÃ­Å¥ovÃ¡ rozhranÃ­ v zÃ¡vislosti na rÅ¯znÃ½ch statickÃ½ch kritÃ©riÃ­ch
 .\"
 .\" SYNOPSIS part
 .\"
@@ -19,32 +19,32 @@ ifrename \- Pøejmenuje sí»ová rozhraní v závislosti na rùznıch statickıch kritér
 .\"
 .SH POPIS
 .B Ifrename 
-je nástroj, kterı umo¾òuje pøiøadit stálı název pro ka¾dé
-sí»ové rozhraní.
+je nÃ¡stroj, kterÃ½ umoÅ¾Åˆuje pÅ™iÅ™adit stÃ¡lÃ½ nÃ¡zev pro kaÅ¾dÃ©
+sÃ­Å¥ovÃ© rozhranÃ­.
 .PP
-Ve vıchozím stavu jsou názvy rozhraní dynamické a ka¾dému sí»ovému rozhraní
-je pøiøazen první dostupnı název
+Ve vÃ½chozÃ­m stavu jsou nÃ¡zvy rozhranÃ­ dynamickÃ© a kaÅ¾dÃ©mu sÃ­Å¥ovÃ©mu rozhranÃ­
+je pÅ™iÅ™azen prvnÃ­ dostupnÃ½ nÃ¡zev
 .RI ( eth0 ", " eth1 "...)."
-Poøadí, v kterém jsou sí»ová rozhraní vytváøena, se mù¾e li¹it. U zabudovanıch
-rozhraní závisí na jejich rozpoznání kernelem pøi spou¹tìní. Vımìnná zaøízení mù¾e
-u¾ivatel pøipojit v jakémkoliv poøadí.
+PoÅ™adÃ­, v kterÃ©m jsou sÃ­Å¥ovÃ¡ rozhranÃ­ vytvÃ¡Å™ena, se mÅ¯Å¾e liÅ¡it. U zabudovanÃ½ch
+rozhranÃ­ zÃ¡visÃ­ na jejich rozpoznÃ¡nÃ­ kernelem pÅ™i spouÅ¡tÄ›nÃ­. VÃ½mÄ›nnÃ¡ zaÅ™Ã­zenÃ­ mÅ¯Å¾e
+uÅ¾ivatel pÅ™ipojit v jakÃ©mkoliv poÅ™adÃ­.
 .PP
 .B Ifrename
-umo¾òuje u¾ivateli rozhodnout, jakı název bude sí»ové rozhraní mít.
+umoÅ¾Åˆuje uÅ¾ivateli rozhodnout, jakÃ½ nÃ¡zev bude sÃ­Å¥ovÃ© rozhranÃ­ mÃ­t.
 .B Ifrename 
-mù¾e vyu¾ít celou øadu
+mÅ¯Å¾e vyuÅ¾Ã­t celou Å™adu
 .IR voleb ", "
-aby urèil, jak jsou názvy rozhraní pøiøazovány sí»ovım rozhraním v systému.
-Nejbì¾nìj¹í volbou je  
+aby urÄil, jak jsou nÃ¡zvy rozhranÃ­ pÅ™iÅ™azovÃ¡ny sÃ­Å¥ovÃ½m rozhranÃ­m v systÃ©mu.
+NejbÄ›Å¾nÄ›jÅ¡Ã­ volbou je  
 .IR "MAC adresa" 
-rozhraní.
+rozhranÃ­.
 .PP
 .B Ifrename
-musí bıt spu¹tìn pøedtím, ne¾ jsou rozhraní aktivována, proto je vìt¹inou pou¾íván
-v rùznıch skriptech (init, hotplug), ale jen zøídka pøímo u¾ivatelem.
-Jako vıchozí,
+musÃ­ bÃ½t spuÅ¡tÄ›n pÅ™edtÃ­m, neÅ¾ jsou rozhranÃ­ aktivovÃ¡na, proto je vÄ›tÅ¡inou pouÅ¾Ã­vÃ¡n
+v rÅ¯znÃ½ch skriptech (init, hotplug), ale jen zÅ™Ã­dka pÅ™Ã­mo uÅ¾ivatelem.
+Jako vÃ½chozÃ­,
 .B ifrename 
-pøejmenuje v¹echna rozhraní pøítomná v  systému pou¾itím namapování definovaného v
+pÅ™ejmenuje vÅ¡echna rozhranÃ­ pÅ™Ã­tomnÃ¡ v  systÃ©mu pouÅ¾itÃ­m namapovÃ¡nÃ­ definovanÃ©ho v
 .IR /etc/iftab .
 .\"
 .\" PARAMETER part
@@ -52,88 +52,88 @@ pøejmenuje v¹echna rozhraní pøítomná v  systému pou¾itím namapování definovaného
 .SH PARAMETRY
 .TP
 .BI "-c " konfiguracni_soubor
-Nastaví konfiguraèní soubor, kterı bude pou¾it (vıchozí je 
+NastavÃ­ konfiguraÄnÃ­ soubor, kterÃ½ bude pouÅ¾it (vÃ½chozÃ­ je 
 .IR /etc/iftab ).
-Konfiguraèní soubor definuje namapování voleb a názvù rozhraní
-a je popsán v
+KonfiguraÄnÃ­ soubor definuje namapovÃ¡nÃ­ voleb a nÃ¡zvÅ¯ rozhranÃ­
+a je popsÃ¡n v
 .IR iftab (5).
 .br
 Pokud je
 .I konfiguracni_soubor
-urèen jako "-", je konfigurace naètena ze stdin.
+urÄen jako "-", je konfigurace naÄtena ze stdin.
 .TP
 .B -p
-Pokusí se zavést moduly jádra pøed pøejmenováním rozhraní. Jako vıchozí 
-prochází
+PokusÃ­ se zavÃ©st moduly jÃ¡dra pÅ™ed pÅ™ejmenovÃ¡nÃ­m rozhranÃ­. Jako vÃ½chozÃ­ 
+prochÃ¡zÃ­
 .B ifrename 
-pouze rozhraní, která jsou ji¾ zavedena a nezavádí automaticky po¾adované
-jaderné moduly. Tento pøepínaè umo¾òuje hladkou integraci se systémem, kterı
-nezavádí moduly pøed voláním
+pouze rozhranÃ­, kterÃ¡ jsou jiÅ¾ zavedena a nezavÃ¡dÃ­ automaticky poÅ¾adovanÃ©
+jadernÃ© moduly. Tento pÅ™epÃ­naÄ umoÅ¾Åˆuje hladkou integraci se systÃ©mem, kterÃ½
+nezavÃ¡dÃ­ moduly pÅ™ed volÃ¡nÃ­m
 .BR ifrename .
 .TP
 .B -d
-Povolí rùzné úpravy specifické pro
+PovolÃ­ rÅ¯znÃ© Ãºpravy specifickÃ© pro
 .B Debian. 
 V kombinaci s
 .BR -p
-budou zavedeny pouze moduly pro rozhraní urèená v
+budou zavedeny pouze moduly pro rozhranÃ­ urÄenÃ¡ v
 .I /etc/network/interface
 .
 .TP
-.BI "-i " rozhraní
-Pøejmenuje pouze urèené
-.IR rozhraní ,
-místo v¹ech rozhraní v systému. Vypí¹e novı název rozhraní.
+.BI "-i " rozhranÃ­
+PÅ™ejmenuje pouze urÄenÃ©
+.IR rozhranÃ­ ,
+mÃ­sto vÅ¡ech rozhranÃ­ v systÃ©mu. VypÃ­Å¡e novÃ½ nÃ¡zev rozhranÃ­.
 .TP
 .BI "-n " novy_nazev
-Kdy¾ je pou¾ito spolu s 
+KdyÅ¾ je pouÅ¾ito spolu s 
 .IR -i ,
-urèí novı název rozhraní. Seznam namapování z konfiguraèního
-souboru je ignorován, rozhraní urèené pomocí 
+urÄÃ­ novÃ½ nÃ¡zev rozhranÃ­. Seznam namapovÃ¡nÃ­ z konfiguraÄnÃ­ho
+souboru je ignorovÃ¡n, rozhranÃ­ urÄenÃ© pomocÃ­ 
 .I -i
-je rovnou pøejmenováno na
+je rovnou pÅ™ejmenovÃ¡no na
 .IR novy_nazev 
-Novı název mù¾e bıt ¾olík (wildcard), ale mù¾e obsahovat pouze jedinou "*".
+NovÃ½ nÃ¡zev mÅ¯Å¾e bÃ½t Å¾olÃ­k (wildcard), ale mÅ¯Å¾e obsahovat pouze jedinou "*".
 .br
-Pokud je pou¾it bez
+Pokud je pouÅ¾it bez
 .IR -i ,
-pøejmenuje rozhraní s pou¾itím pouze tìch namapování, která by je pøejmenovala na
+pÅ™ejmenuje rozhranÃ­ s pouÅ¾itÃ­m pouze tÄ›ch namapovÃ¡nÃ­, kterÃ¡ by je pÅ™ejmenovala na
 .IR novy_nazev .
-Novı název nesmí bıt ¾olík. Tento zpùsob pou¾ití ifrename 
+NovÃ½ nÃ¡zev nesmÃ­ bÃ½t Å¾olÃ­k. Tento zpÅ¯sob pouÅ¾itÃ­ ifrename 
 .RI ( -n " bez " -i )
-není doporuèen, proto¾e je neefektivní. Musejí bıt zpracována v¹echna rozhraní systému, 
-a proto není ve vìt¹inì pøípadù rychlej¹í ne¾ kdyby je ifrename pøejmenovalo v¹echny (bez
-.IR -n " a zároveò bez " -i ).
+nenÃ­ doporuÄen, protoÅ¾e je neefektivnÃ­. MusejÃ­ bÃ½t zpracovÃ¡na vÅ¡echna rozhranÃ­ systÃ©mu, 
+a proto nenÃ­ ve vÄ›tÅ¡inÄ› pÅ™Ã­padÅ¯ rychlejÅ¡Ã­ neÅ¾ kdyby je ifrename pÅ™ejmenovalo vÅ¡echny (bez
+.IR -n " a zÃ¡roveÅˆ bez " -i ).
 .TP
 .B -t
-Povolí podporu pøevzetí názvù. To umo¾ní vımìnu názvù rozhraní
-mezi dvìma èi více rozhraními.
+PovolÃ­ podporu pÅ™evzetÃ­ nÃ¡zvÅ¯. To umoÅ¾nÃ­ vÃ½mÄ›nu nÃ¡zvÅ¯ rozhranÃ­
+mezi dvÄ›ma Äi vÃ­ce rozhranÃ­mi.
 .br
-Pøevzetí umo¾òuje rozhraní "ukrást" název jinému rozhraní.
-To funguje pouze s jádrem 2.6.x a pokud druhé rozhraní nebì¾í.
-Tímpádem není kompatibilní s Hotplug. Druhému rozhraní je pøiøazen
-náhodnı název, kterı lze pozdìji pomocí "ifrename" zmìnit.
+PÅ™evzetÃ­ umoÅ¾Åˆuje rozhranÃ­ "ukrÃ¡st" nÃ¡zev jinÃ©mu rozhranÃ­.
+To funguje pouze s jÃ¡drem 2.6.x a pokud druhÃ© rozhranÃ­ nebÄ›Å¾Ã­.
+TÃ­mpÃ¡dem nenÃ­ kompatibilnÃ­ s Hotplug. DruhÃ©mu rozhranÃ­ je pÅ™iÅ™azen
+nÃ¡hodnÃ½ nÃ¡zev, kterÃ½ lze pozdÄ›ji pomocÃ­ "ifrename" zmÄ›nit.
 .br
-Poèet pøevzetí je omezen, aby se zabránilo nekoneènım smyèkám,
-a proto nemusejí bıt nìkteré komplexní vícecestné situace správnì zpracovány.
+PoÄet pÅ™evzetÃ­ je omezen, aby se zabrÃ¡nilo nekoneÄnÃ½m smyÄkÃ¡m,
+a proto nemusejÃ­ bÃ½t nÄ›kterÃ© komplexnÃ­ vÃ­cecestnÃ© situace sprÃ¡vnÄ› zpracovÃ¡ny.
 .br
-V ka¾dém pøípadì není pøevod názvù a ani pou¾ívání této mo¾nosti doporuèeno,
-je lep¹í zvolit pro rozhraní jedineèné a jednoznaèné názvy...
+V kaÅ¾dÃ©m pÅ™Ã­padÄ› nenÃ­ pÅ™evod nÃ¡zvÅ¯ a ani pouÅ¾Ã­vÃ¡nÃ­ tÃ©to moÅ¾nosti doporuÄeno,
+je lepÅ¡Ã­ zvolit pro rozhranÃ­ jedineÄnÃ© a jednoznaÄnÃ© nÃ¡zvy...
 .TP
 .B -D
-Re¾im dry-run ("naneèisto"). Ifrename nezmìní ¾ádné rozhraní, pouze vypí¹e
-novı název rozhraní, pokud je to mo¾né, a skonèí.
+ReÅ¾im dry-run ("naneÄisto"). Ifrename nezmÄ›nÃ­ Å¾Ã¡dnÃ© rozhranÃ­, pouze vypÃ­Å¡e
+novÃ½ nÃ¡zev rozhranÃ­, pokud je to moÅ¾nÃ©, a skonÄÃ­.
 .br
-V re¾imu dry-run nejsou øe¹eny wildcards. Novı název rozhraní je vyti¹tìn
-i v pøípadì, ¾e je stejnı jako pùvodní název.
+V reÅ¾imu dry-run nejsou Å™eÅ¡eny wildcards. NovÃ½ nÃ¡zev rozhranÃ­ je vytiÅ¡tÄ›n
+i v pÅ™Ã­padÄ›, Å¾e je stejnÃ½ jako pÅ¯vodnÃ­ nÃ¡zev.
 .TP
 .B -V
-U¾vanìnı re¾im. Ifrename zobrazí interní vısledky prùchodu svım
-konfiguraèním souborem a dotazy na volby rozhraní. V kombinaci s
-pøepínaèem
+UÅ¾vanÄ›nÃ½ reÅ¾im. Ifrename zobrazÃ­ internÃ­ vÃ½sledky prÅ¯chodu svÃ½m
+konfiguraÄnÃ­m souborem a dotazy na volby rozhranÃ­. V kombinaci s
+pÅ™epÃ­naÄem
 .I dry-run
-pøedstavuje dobrı zpùsob debugování komplexních nastavení nebo triviálních
-problémù.
+pÅ™edstavuje dobrÃ½ zpÅ¯sob debugovÃ¡nÃ­ komplexnÃ­ch nastavenÃ­ nebo triviÃ¡lnÃ­ch
+problÃ©mÅ¯.
 .\"
 .\" AUTHOR part
 .\"
@@ -142,8 +142,8 @@ Jean Tourrilhes \- jt@hpl.hp.com
 .\"
 .\" TRANSLATION part
 .\"
-.SH PØEKLAD
-Pavel Heimlich \- tropikhajma@seznam.cz, bøezen 2005 (wireless_tools.28pre4).
+.SH PÅ˜EKLAD
+Pavel Heimlich \- tropikhajma@seznam.cz, bÅ™ezen 2005 (wireless_tools.28pre4).
 .\"
 .\" FILES part
 .\"
@@ -152,7 +152,7 @@ Pavel Heimlich \- tropikhajma@seznam.cz, bøezen 2005 (wireless_tools.28pre4).
 .\"
 .\" SEE ALSO part
 .\"
-.SH DAL©Í INFORMACE
+.SH DALÅ Ã INFORMACE
 .BR ifconfig (8),
 .BR ip (8),
 .BR iftab (5).

--- a/wireless_tools/cs/iftab.5
+++ b/wireless_tools/cs/iftab.5
@@ -1,160 +1,160 @@
 .\" Jean II - HPL - 2004
 .\" iftab.5
 .\"
-.TH IFTAB 5 "1.bøezen 2004" "wireless-tools" "Linux - Manuál programátora"
+.TH IFTAB 5 "1.bÅ™ezen 2004" "wireless-tools" "Linux - ManuÃ¡l programÃ¡tora"
 .\"
 .\" NAME part
 .\"
-.SH JMÉNO
-iftab \- statické informace o sí»ovıch rozhraních
+.SH JMÃ‰NO
+iftab \- statickÃ© informace o sÃ­Å¥ovÃ½ch rozhranÃ­ch
 .\"
 .\" DESCRIPTION part
 .\"
 .SH POPIS
 Soubor
 .B /etc/iftab
-obsahuje popisnou informaci o rùznıch sí»ovıch rozhraních.
+obsahuje popisnou informaci o rÅ¯znÃ½ch sÃ­Å¥ovÃ½ch rozhranÃ­ch.
 .B iftab
-je pou¾íván pouze programem
+je pouÅ¾Ã­vÃ¡n pouze programem
 .IR ifrename (8)
-k pøiøazení stálıch názvù sí»ovıch rozhraní ka¾dému sí»ovému rozhraní.
+k pÅ™iÅ™azenÃ­ stÃ¡lÃ½ch nÃ¡zvÅ¯ sÃ­Å¥ovÃ½ch rozhranÃ­ kaÅ¾dÃ©mu sÃ­Å¥ovÃ©mu rozhranÃ­.
 .PP
 .B /etc/iftab
 definuje sadu
-.IR namapování .
-Ka¾dé namapování obsahuje název rozhraní a sadu deskriptorù.
-Deskriptory umo¾òují
+.IR namapovÃ¡nÃ­ .
+KaÅ¾dÃ© namapovÃ¡nÃ­ obsahuje nÃ¡zev rozhranÃ­ a sadu deskriptorÅ¯.
+Deskriptory umoÅ¾ÅˆujÃ­
 .B ifrename
-identifikovat ka¾dé sí»ové rozhraní v  systému. Pokud sí»ové rozhraní odpovídá
-v¹em deskriptorùm z namapování,
+identifikovat kaÅ¾dÃ© sÃ­Å¥ovÃ© rozhranÃ­ v  systÃ©mu. Pokud sÃ­Å¥ovÃ© rozhranÃ­ odpovÃ­dÃ¡
+vÅ¡em deskriptorÅ¯m z namapovÃ¡nÃ­,
 .B ifrename
-se pokusí zmìnit název rozhraní na název urèenı v namapování.
+se pokusÃ­ zmÄ›nit nÃ¡zev rozhranÃ­ na nÃ¡zev urÄenÃ½ v namapovÃ¡nÃ­.
 .\"
 .\" MAPPINGS part
 .\"
-.SH NAMAPOVÁNÍ
-Ka¾dé namapování je popsáno na zvlá¹tní øádce, zaèínající
+.SH NAMAPOVÃNÃ
+KaÅ¾dÃ© namapovÃ¡nÃ­ je popsÃ¡no na zvlÃ¡Å¡tnÃ­ Å™Ã¡dce, zaÄÃ­najÃ­cÃ­
 .IR "interface name" ,
-(názvem rozhraní) a obsahuje sadu
-.IR deskriptorù ,
-oddìlenıch mezerami nebo tabulátory.
+(nÃ¡zvem rozhranÃ­) a obsahuje sadu
+.IR deskriptorÅ¯ ,
+oddÄ›lenÃ½ch mezerami nebo tabulÃ¡tory.
 .PP
-Vztah mezi deskriptory v namapování je
-.IR "logické a" .
-Namapování odpovídá sí»ovému rozhraní, pouze kdy¾ odpovídají v¹echny deskriptory.
-Pokud sí»ové rozhraní nepodporuje urèitı deskriptor, nebude vyhovovat ¾ádnému
-namapování pou¾ívajícímu tento deskriptor.
+Vztah mezi deskriptory v namapovÃ¡nÃ­ je
+.IR "logickÃ© a" .
+NamapovÃ¡nÃ­ odpovÃ­dÃ¡ sÃ­Å¥ovÃ©mu rozhranÃ­, pouze kdyÅ¾ odpovÃ­dajÃ­ vÅ¡echny deskriptory.
+Pokud sÃ­Å¥ovÃ© rozhranÃ­ nepodporuje urÄitÃ½ deskriptor, nebude vyhovovat Å¾Ã¡dnÃ©mu
+namapovÃ¡nÃ­ pouÅ¾Ã­vajÃ­cÃ­mu tento deskriptor.
 .PP
-Pokud je potøeba pou¾ít alternativní deskriptory pro název rozhraní
-(logické nebo), vytvoøte dvì rùzná namapování se stejnım názvem rozhraní
-(na ka¾dém øádku jednu).
+Pokud je potÅ™eba pouÅ¾Ã­t alternativnÃ­ deskriptory pro nÃ¡zev rozhranÃ­
+(logickÃ© nebo), vytvoÅ™te dvÄ› rÅ¯znÃ¡ namapovÃ¡nÃ­ se stejnÃ½m nÃ¡zvem rozhranÃ­
+(na kaÅ¾dÃ©m Å™Ã¡dku jednu).
 .B Ifrename
-v¾dycky pou¾ije první odpovídající namapování od
+vÅ¾dycky pouÅ¾ije prvnÃ­ odpovÃ­dajÃ­cÃ­ namapovÃ¡nÃ­ od
 .I konce
 .BR iftab ,
-proto by restriktivnìj¹í namapování mìla bıt uvedena naposled.
+proto by restriktivnÄ›jÅ¡Ã­ namapovÃ¡nÃ­ mÄ›la bÃ½t uvedena naposled.
 .\"
 .\" INTERFACE NAME part
 .\"
-.SH NÁZEV ROZHRANÍ
-První èástí ka¾dého namapování je název rozhraní. Pokud sí»ové rozhraní
-odpovídá v¹em deskriptorùm v namapování,
+.SH NÃZEV ROZHRANÃ
+PrvnÃ­ ÄÃ¡stÃ­ kaÅ¾dÃ©ho namapovÃ¡nÃ­ je nÃ¡zev rozhranÃ­. Pokud sÃ­Å¥ovÃ© rozhranÃ­
+odpovÃ­dÃ¡ vÅ¡em deskriptorÅ¯m v namapovÃ¡nÃ­,
 .B ifrename
-se pokusí zmìnit název rozhraní na název urèenı v namapování.
+se pokusÃ­ zmÄ›nit nÃ¡zev rozhranÃ­ na nÃ¡zev urÄenÃ½ v namapovÃ¡nÃ­.
 .PP
-Název rozhraní v namapování je buïto pouhı název rozhraní (jako tøeba
+NÃ¡zev rozhranÃ­ v namapovÃ¡nÃ­ je buÄto pouhÃ½ nÃ¡zev rozhranÃ­ (jako tÅ™eba
 .IR eth2 " nebo " wlan0 )
-nebo ¹ablona obsahující jediného ¾olíka (wildcard) (napø.
+nebo Å¡ablona obsahujÃ­cÃ­ jedinÃ©ho Å¾olÃ­ka (wildcard) (napÅ™.
 .IR eth* " nebo " wlan* ).
-V pøípadì ¾olíka nahradí jádro znak "*" za nejni¾¹í dostupné
-celé èíslo, které zajistí jedineènost názvu rozhraní.
+V pÅ™Ã­padÄ› Å¾olÃ­ka nahradÃ­ jÃ¡dro znak "*" za nejniÅ¾Å¡Ã­ dostupnÃ©
+celÃ© ÄÃ­slo, kterÃ© zajistÃ­ jedineÄnost nÃ¡zvu rozhranÃ­.
 .\"
 .\" DESCRIPTORS part
 .\"
 .SH DESKRIPTORY
-Ka¾dı deskriptor je slo¾en z názvu deskriptoru a hodnoty deskriptoru.
-Deskriptory urèují statické vlastnosti sí»ového rozhraní, jejich
-cílem je jednoznaènì identifikovat ka¾dı kus hardware.
+KaÅ¾dÃ½ deskriptor je sloÅ¾en z nÃ¡zvu deskriptoru a hodnoty deskriptoru.
+Deskriptory urÄujÃ­ statickÃ© vlastnosti sÃ­Å¥ovÃ©ho rozhranÃ­, jejich
+cÃ­lem je jednoznaÄnÄ› identifikovat kaÅ¾dÃ½ kus hardware.
 .PP
-Vìt¹ina u¾ivatelù pou¾ije pouze volbu
+VÄ›tÅ¡ina uÅ¾ivatelÅ¯ pouÅ¾ije pouze volbu
 .B mac
-, ostatní volby jsou urèeny k zvlá¹tním nastavením.
+, ostatnÃ­ volby jsou urÄeny k zvlÃ¡Å¡tnÃ­m nastavenÃ­m.
 .TP
 .BI mac " MAC adresa"
-Porovná MAC adresu rozhraní se zadanou MAC adresou. MAC adresu
-rozhraní je mo¾né zobrazit pomocí
+PorovnÃ¡ MAC adresu rozhranÃ­ se zadanou MAC adresou. MAC adresu
+rozhranÃ­ je moÅ¾nÃ© zobrazit pomocÃ­
 .IR ifconfig (8)
 nebo
 .IR ip (8).
-Zadaná MAC adresa mù¾e 
-obsahovat "*" pro vıbìr ¾olíkù (wildcards).
+ZadanÃ¡ MAC adresa mÅ¯Å¾e 
+obsahovat "*" pro vÃ½bÄ›r Å¾olÃ­kÅ¯ (wildcards).
 .br
-Je to nejbì¾nìj¹í volba, proto¾e vìt¹ina rozhraní má unikátní MAC
-adresu, která umo¾òuje sí»ové rozhraní jednoznaènì identifikovat.
-Nicménì nìkterá rozhraní nemají MAC adresu, dokud nejsou aktivována
-a v takovém pøípadì je u¾ití tohoto selektoru o¹idné.
+Je to nejbÄ›Å¾nÄ›jÅ¡Ã­ volba, protoÅ¾e vÄ›tÅ¡ina rozhranÃ­ mÃ¡ unikÃ¡tnÃ­ MAC
+adresu, kterÃ¡ umoÅ¾Åˆuje sÃ­Å¥ovÃ© rozhranÃ­ jednoznaÄnÄ› identifikovat.
+NicmÃ©nÄ› nÄ›kterÃ¡ rozhranÃ­ nemajÃ­ MAC adresu, dokud nejsou aktivovÃ¡na
+a v takovÃ©m pÅ™Ã­padÄ› je uÅ¾itÃ­ tohoto selektoru oÅ¡idnÃ©.
 .TP
 .BI arp " typ arp"
-Porovná typ ARP (ARP Type)(také zvané "Link Type") rozhraní se zadanım typem ARP.
-Typ ARP u rozhraní je mo¾né zobrazit pomocí
+PorovnÃ¡ typ ARP (ARP Type)(takÃ© zvanÃ© "Link Type") rozhranÃ­ se zadanÃ½m typem ARP.
+Typ ARP u rozhranÃ­ je moÅ¾nÃ© zobrazit pomocÃ­
 .IR ifconfig (8)
 nebo
 .IR ip (8).
 .br
-Tento selektor je u¾iteènı pokud ovladaè vytváøí více sí»ovıch rozhraní
-pro jedinou sí»ovou kartu.
+Tento selektor je uÅ¾iteÄnÃ½ pokud ovladaÄ vytvÃ¡Å™Ã­ vÃ­ce sÃ­Å¥ovÃ½ch rozhranÃ­
+pro jedinou sÃ­Å¥ovou kartu.
 .TP
-.BI driver " název ovladaèe"
-Porovná název ovladaèe rozhraní se zadanım názvem ovladaèe.
-Název ovladaèe rozhraní je mo¾né zobrazit pomocí
+.BI driver " nÃ¡zev ovladaÄe"
+PorovnÃ¡ nÃ¡zev ovladaÄe rozhranÃ­ se zadanÃ½m nÃ¡zvem ovladaÄe.
+NÃ¡zev ovladaÄe rozhranÃ­ je moÅ¾nÃ© zobrazit pomocÃ­
 .IR "ethtool -i" (8).
 .TP
-.BI businfo " informace o sbìrnici"
-Porovná informaci o sbìrnici rozhraní rozhraní se zadanou informací
-o sbìrnici. Informaci o sbìrnici rozhraní je mo¾né zobrazit pomocí
+.BI businfo " informace o sbÄ›rnici"
+PorovnÃ¡ informaci o sbÄ›rnici rozhranÃ­ rozhranÃ­ se zadanou informacÃ­
+o sbÄ›rnici. Informaci o sbÄ›rnici rozhranÃ­ je moÅ¾nÃ© zobrazit pomocÃ­
 .IR "ethtool -i" (8).
 .TP
 .BI firmware " verze firmware"
-Porovná verzi firmware rozhraní s informací o verzi firmware.
-Revizi firmware rozhraní je mo¾né zobrazit pomocí
+PorovnÃ¡ verzi firmware rozhranÃ­ s informacÃ­ o verzi firmware.
+Revizi firmware rozhranÃ­ je moÅ¾nÃ© zobrazit pomocÃ­
 .IR "ethtool -i" (8).
 .TP
 .BI baseaddress " port"
-Porovná port rozhraní se zadanım portem. Port rozhraní je mo¾né zobrazit pomocí
+PorovnÃ¡ port rozhranÃ­ se zadanÃ½m portem. Port rozhranÃ­ je moÅ¾nÃ© zobrazit pomocÃ­
 .IR ifconfig (8).
 .br
-Proto¾e vìt¹ina karet pou¾ívá dynamické pøidìlování portù, je
-tato volba u¾iteèná pouze pro ISA a EISA karty.
+ProtoÅ¾e vÄ›tÅ¡ina karet pouÅ¾Ã­vÃ¡ dynamickÃ© pÅ™idÄ›lovÃ¡nÃ­ portÅ¯, je
+tato volba uÅ¾iteÄnÃ¡ pouze pro ISA a EISA karty.
 .TP
-.BI irq " èíslo pøeru¹ení"
-Porovná èíslo pøeru¹ení (IRQ) rozhraní se zadanım
-èíslem pøeru¹ení. Èíslo pøeru¹ení rozhraní je mo¾né zobrazit pomocí
+.BI irq " ÄÃ­slo pÅ™eruÅ¡enÃ­"
+PorovnÃ¡ ÄÃ­slo pÅ™eruÅ¡enÃ­ (IRQ) rozhranÃ­ se zadanÃ½m
+ÄÃ­slem pÅ™eruÅ¡enÃ­. ÄŒÃ­slo pÅ™eruÅ¡enÃ­ rozhranÃ­ je moÅ¾nÃ© zobrazit pomocÃ­
 .IR ifconfig (8).
 .br
-Proto¾e pøeru¹ení mohou bıt sdílená, obvykle tento selektor nestaèí
-k jednoznaèné identifikaci rozhraní.
+ProtoÅ¾e pÅ™eruÅ¡enÃ­ mohou bÃ½t sdÃ­lenÃ¡, obvykle tento selektor nestaÄÃ­
+k jednoznaÄnÃ© identifikaci rozhranÃ­.
 .TP
-.BI iwproto " bezdrátovı protokol"
-Porovná bezdrátovı protokol rozhraní se zadanım
-bezdrátovım protokolem. Bezdrátovı protokol rozhraní je mo¾né zobrazit pomocí
+.BI iwproto " bezdrÃ¡tovÃ½ protokol"
+PorovnÃ¡ bezdrÃ¡tovÃ½ protokol rozhranÃ­ se zadanÃ½m
+bezdrÃ¡tovÃ½m protokolem. BezdrÃ¡tovÃ½ protokol rozhranÃ­ je moÅ¾nÃ© zobrazit pomocÃ­
 .IR iwconfig (8).
 .br
-Tato volba je podporována pouze na bezdrátovıch rozhraních a nestaèí
-k jednoznaèné identifikaci rozhraní.
+Tato volba je podporovÃ¡na pouze na bezdrÃ¡tovÃ½ch rozhranÃ­ch a nestaÄÃ­
+k jednoznaÄnÃ© identifikaci rozhranÃ­.
 .TP
 .BI pcmciaslot " pcmcia slot"
-Porovná èíslo Pcmcia socketu rozhraní se zadanım èíslem slotu. Èíslo Pcmcia socketu
-rozhraní je mo¾né zobrazit pomocí
+PorovnÃ¡ ÄÃ­slo Pcmcia socketu rozhranÃ­ se zadanÃ½m ÄÃ­slem slotu. ÄŒÃ­slo Pcmcia socketu
+rozhranÃ­ je moÅ¾nÃ© zobrazit pomocÃ­
 .IR "cardctl ident" (8).
 .br
-Tato volba je obvykle podporována pouze na 16 bitovıch kartách, pro 32 bitové
-karty je lep¹í pou¾ít selektor
+Tato volba je obvykle podporovÃ¡na pouze na 16 bitovÃ½ch kartÃ¡ch, pro 32 bitovÃ©
+karty je lepÅ¡Ã­ pouÅ¾Ã­t selektor
 .BR businfo .
 .\"
 .\" EXAMPLE part
 .\"
-.SH PØÍKLAD
-# Toto je komentáø
+.SH PÅ˜ÃKLAD
+# Toto je komentÃ¡Å™
 .br
 eth2		mac 08:00:09:DE:82:0E
 .br
@@ -171,8 +171,8 @@ Jean Tourrilhes \- jt@hpl.hp.com
 .\"
 .\" TRANSLATION part
 .\"
-.SH PØEKLAD
-Pavel Heimlich \- tropikhajma@seznam.cz, bøezen 2005 (wireless_tools.28pre4).
+.SH PÅ˜EKLAD
+Pavel Heimlich \- tropikhajma@seznam.cz, bÅ™ezen 2005 (wireless_tools.28pre4).
 .\"
 .\" FILES part
 .\"
@@ -181,7 +181,7 @@ Pavel Heimlich \- tropikhajma@seznam.cz, bøezen 2005 (wireless_tools.28pre4).
 .\"
 .\" SEE ALSO part
 .\"
-.SH DAL©Í INFORMACE
+.SH DALÅ Ã INFORMACE
 .BR ifrename (8),
 .BR ifconfig (8),
 .BR ip (8),

--- a/wireless_tools/cs/iwconfig.8
+++ b/wireless_tools/cs/iwconfig.8
@@ -1,19 +1,19 @@
 .\" Jean II - HPLB - 1996 => HPL - 2004
 .\" iwconfig.8
 .\"
-.TH IWCONFIG 8 "22.èervna 2004" "wireless-tools" "Linux - Manuál programátora"
+.TH IWCONFIG 8 "22.Äervna 2004" "wireless-tools" "Linux - ManuÃ¡l programÃ¡tora"
 .\"
 .\" NAME part
 .\"
-.SH JMÉNO
-iwconfig \- nastavuje rozhraní bezdrátové sítì
+.SH JMÃ‰NO
+iwconfig \- nastavuje rozhranÃ­ bezdrÃ¡tovÃ© sÃ­tÄ›
 .\"
 .\" SYNOPSIS part
 .\"
 .SH SYNTAXE
-.BI "iwconfig [" rozhraní ]
+.BI "iwconfig [" rozhranÃ­ ]
 .br
-.BI "iwconfig " rozhraní " [essid " X "] [nwid " N "] [mode " M "] [freq " F "]
+.BI "iwconfig " rozhranÃ­ " [essid " X "] [nwid " N "] [mode " M "] [freq " F "]
 .br
 .BI "                   [channel " C ] [sens " S "] [ap " A "] [nick " NN ]
 .br
@@ -31,44 +31,44 @@ iwconfig \- nastavuje rozhraní bezdrátové sítì
 .\"
 .SH POPIS
 .B Iwconfig
-je podobnı pøíkazu
+je podobnÃ½ pÅ™Ã­kazu
 .IR ifconfig (8),
-ale je vìnovanı bezdrátovım rozhraním. Je pou¾íván k nastavení tìch parametrù 
-sí»ovıch rozhraní, které jsou specifické pro bezdrátovı provoz (napø. frekvence).
+ale je vÄ›novanÃ½ bezdrÃ¡tovÃ½m rozhranÃ­m. Je pouÅ¾Ã­vÃ¡n k nastavenÃ­ tÄ›ch parametrÅ¯ 
+sÃ­Å¥ovÃ½ch rozhranÃ­, kterÃ© jsou specifickÃ© pro bezdrÃ¡tovÃ½ provoz (napÅ™. frekvence).
 .B Iwconfig
-mù¾e bıt také pou¾it k zobrazení tìchto parametrù a bezdrátovıch
-statistik (získanıch z
+mÅ¯Å¾e bÃ½t takÃ© pouÅ¾it k zobrazenÃ­ tÄ›chto parametrÅ¯ a bezdrÃ¡tovÃ½ch
+statistik (zÃ­skanÃ½ch z
 .IR /proc/net/wireless ).
 .PP
-V¹echny tyto parametry a statistiky jsou závislé na zaøízení. Ka¾dı ovladaè
-poskytuje, v závislosti na hardwarové podpoøe, jen nìkteré z nich
-a rozsah hodnot se mù¾e mìnit. Prosím obracejte se na manuálové stránky
-jednotlivıch zaøízení pro dal¹í detaily.
+VÅ¡echny tyto parametry a statistiky jsou zÃ¡vislÃ© na zaÅ™Ã­zenÃ­. KaÅ¾dÃ½ ovladaÄ
+poskytuje, v zÃ¡vislosti na hardwarovÃ© podpoÅ™e, jen nÄ›kterÃ© z nich
+a rozsah hodnot se mÅ¯Å¾e mÄ›nit. ProsÃ­m obracejte se na manuÃ¡lovÃ© strÃ¡nky
+jednotlivÃ½ch zaÅ™Ã­zenÃ­ pro dalÅ¡Ã­ detaily.
 .\"
 .\" PARAMETER part
 .\"
 .SH PARAMETRY
 .TP
 .B essid
-Nastaví ESSID (nebo Network Name - u nìkterıch produktù mù¾e bıt nazváno
-Domain ID). ESSID se pou¾ívá k identifikaci bunìk, které jsou
-souèástí stejné virtuální sítì.
+NastavÃ­ ESSID (nebo Network Name - u nÄ›kterÃ½ch produktÅ¯ mÅ¯Å¾e bÃ½t nazvÃ¡no
+Domain ID). ESSID se pouÅ¾Ã­vÃ¡ k identifikaci bunÄ›k, kterÃ© jsou
+souÄÃ¡stÃ­ stejnÃ© virtuÃ¡lnÃ­ sÃ­tÄ›.
 .br
-Na rozdíl od adresy AP nebo NWID, která urèuje jedinou buòku, ESSID
-urèuje skupinu bunìk, spojenıch opakovaèi (repeater) nebo infrastrukturou,
-mezi kterımi mù¾e u¾ivatel transparentnì pøecházet.
+Na rozdÃ­l od adresy AP nebo NWID, kterÃ¡ urÄuje jedinou buÅˆku, ESSID
+urÄuje skupinu bunÄ›k, spojenÃ½ch opakovaÄi (repeater) nebo infrastrukturou,
+mezi kterÃ½mi mÅ¯Å¾e uÅ¾ivatel transparentnÄ› pÅ™echÃ¡zet.
 .br
-U nìkterıch karet je mo¾né vypnout kontrolu ESSID (promiskuitní ESSID)
-pomocí
+U nÄ›kterÃ½ch karet je moÅ¾nÃ© vypnout kontrolu ESSID (promiskuitnÃ­ ESSID)
+pomocÃ­
 .IR off " nebo " any " (a " on
-k opìtovnému zapnutí).
+k opÄ›tovnÃ©mu zapnutÃ­).
 .br
-Pokud je ESSID sítì jedním z klíèovıch slov
+Pokud je ESSID sÃ­tÄ› jednÃ­m z klÃ­ÄovÃ½ch slov
 .RI ( off ", " on " nebo " any ),
-pou¾ije se
+pouÅ¾ije se
 .I --
 .br 
-.B Pøíklady:
+.B PÅ™Ã­klady:
 .br
 .I "	iwconfig eth0 essid any"
 .br
@@ -77,38 +77,38 @@ pou¾ije se
 .I "	iwconfig eth0 essid -- ""ANY""
 .TP
 .BR nwid / domain
-Nastaví Network ID (u nìkterıch produktù mù¾e bıt nazváno Domain ID).
-Proto¾e v¹echny sousedící bezdrátové sítì sdílejí stejné médium, je
-tento parametr pou¾íván k jejich rozli¹ení (tvorbì logickıch kolokovanıch
-sítí) a identifikaci nodù patøících do stejné buòky.
+NastavÃ­ Network ID (u nÄ›kterÃ½ch produktÅ¯ mÅ¯Å¾e bÃ½t nazvÃ¡no Domain ID).
+ProtoÅ¾e vÅ¡echny sousedÃ­cÃ­ bezdrÃ¡tovÃ© sÃ­tÄ› sdÃ­lejÃ­ stejnÃ© mÃ©dium, je
+tento parametr pouÅ¾Ã­vÃ¡n k jejich rozliÅ¡enÃ­ (tvorbÄ› logickÃ½ch kolokovanÃ½ch
+sÃ­tÃ­) a identifikaci nodÅ¯ patÅ™Ã­cÃ­ch do stejnÃ© buÅˆky.
 .br
-Tento parametr se pou¾ívá pouze u pre-802.11 zaøízení. Protokol 802.11
-pou¾ívá pro tuto funkci ESSID a adresu AP.
+Tento parametr se pouÅ¾Ã­vÃ¡ pouze u pre-802.11 zaÅ™Ã­zenÃ­. Protokol 802.11
+pouÅ¾Ã­vÃ¡ pro tuto funkci ESSID a adresu AP.
 .br
-U nìkterıch karet je mo¾né vypnout kontrolu Network ID (promiskuitní NWID)
-pomocí 
+U nÄ›kterÃ½ch karet je moÅ¾nÃ© vypnout kontrolu Network ID (promiskuitnÃ­ NWID)
+pomocÃ­ 
 .IR off " (a " on
-k opìtovnému zapnutí).
+k opÄ›tovnÃ©mu zapnutÃ­).
 .br
-.B Pøíklady:
+.B PÅ™Ã­klady:
 .br
 .I "	iwconfig eth0 nwid AB34
 .br
 .I "	iwconfig eth0 nwid off"
 .TP
 .BR freq / channel
-Nastaví pracovní frekvenci nebo kanál zaøízení. Hodnota ni¾¹í ne¾ 1000
-znamená èíslo kanálu, hodnota vy¹¹í ne¾ 1000 je frekvence v Hz.
-Je mo¾né pøipojit k hodnotì pøíponu k, M nebo G (napøíklad "2.46G" pro
-frekvenci 2,46 GHz), nebo doplnit dostateènı poèet nul.
+NastavÃ­ pracovnÃ­ frekvenci nebo kanÃ¡l zaÅ™Ã­zenÃ­. Hodnota niÅ¾Å¡Ã­ neÅ¾ 1000
+znamenÃ¡ ÄÃ­slo kanÃ¡lu, hodnota vyÅ¡Å¡Ã­ neÅ¾ 1000 je frekvence v Hz.
+Je moÅ¾nÃ© pÅ™ipojit k hodnotÄ› pÅ™Ã­ponu k, M nebo G (napÅ™Ã­klad "2.46G" pro
+frekvenci 2,46 GHz), nebo doplnit dostateÄnÃ½ poÄet nul.
 .br
-Kanály jsou obvykle èíslovány od 1, je mo¾né pou¾ít
+KanÃ¡ly jsou obvykle ÄÃ­slovÃ¡ny od 1, je moÅ¾nÃ© pouÅ¾Ã­t
 .IR iwlist (8)
-k získání celkového poètu kanálù, seznamu dostupnıch frekvencí a zobrazení souèasné
-frekvence jako kanálu. V závislosti na pøedpisech mohou bıt nìkteré frekvence/kanály
-nedostupné.
+k zÃ­skÃ¡nÃ­ celkovÃ©ho poÄtu kanÃ¡lÅ¯, seznamu dostupnÃ½ch frekvencÃ­ a zobrazenÃ­ souÄasnÃ©
+frekvence jako kanÃ¡lu. V zÃ¡vislosti na pÅ™edpisech mohou bÃ½t nÄ›kterÃ© frekvence/kanÃ¡ly
+nedostupnÃ©.
 .br
-.B Pøíklady:
+.B PÅ™Ã­klady:
 .br
 .I "	iwconfig eth0 freq 2422000000"
 .br
@@ -117,66 +117,66 @@ nedostupné.
 .I "	iwconfig eth0 channel 3"
 .TP
 .B sens
-Nastaví práh citlivosti. To je nejni¾¹í úroveò síly signálu pøi které
-hardware pova¾uje pøijaté pakety za pou¾itelné. Kladné hodnoty jsou
-interpretovány jako hodnota pou¾ívaná hardwarem nebo jako procenta,
-negativní hodnoty jako dBm. V závislosti na hardwarové implementaci mù¾e
-mít tento parametr dal¹í funkce.
+NastavÃ­ prÃ¡h citlivosti. To je nejniÅ¾Å¡Ã­ ÃºroveÅˆ sÃ­ly signÃ¡lu pÅ™i kterÃ©
+hardware povaÅ¾uje pÅ™ijatÃ© pakety za pouÅ¾itelnÃ©. KladnÃ© hodnoty jsou
+interpretovÃ¡ny jako hodnota pouÅ¾Ã­vanÃ¡ hardwarem nebo jako procenta,
+negativnÃ­ hodnoty jako dBm. V zÃ¡vislosti na hardwarovÃ© implementaci mÅ¯Å¾e
+mÃ­t tento parametr dalÅ¡Ã­ funkce.
 .br
-Tento parametr mù¾e ovládat práh pøíjmu (receive threshold) - nejni¾¹í úroveò signálu
-pøi které se hardware pokusí o pøíjem paketu, slab¹í signál je ignorován. Mù¾e také
-nastavovat práh ústupu (defer threshold) - nejni¾¹í úroveò signálu, od které hardware 
-pova¾uje kanál za obsazenı. Pøi správném nastavení tìchto prahù karta neztrácí èas 
-pøíjmen ¹umu. U moderních zaøízení se zdá, ¾e tyto prahy regulují automaticky.
+Tento parametr mÅ¯Å¾e ovlÃ¡dat prÃ¡h pÅ™Ã­jmu (receive threshold) - nejniÅ¾Å¡Ã­ ÃºroveÅˆ signÃ¡lu
+pÅ™i kterÃ© se hardware pokusÃ­ o pÅ™Ã­jem paketu, slabÅ¡Ã­ signÃ¡l je ignorovÃ¡n. MÅ¯Å¾e takÃ©
+nastavovat prÃ¡h Ãºstupu (defer threshold) - nejniÅ¾Å¡Ã­ ÃºroveÅˆ signÃ¡lu, od kterÃ© hardware 
+povaÅ¾uje kanÃ¡l za obsazenÃ½. PÅ™i sprÃ¡vnÃ©m nastavenÃ­ tÄ›chto prahÅ¯ karta neztrÃ¡cÃ­ Äas 
+pÅ™Ã­jmen Å¡umu. U modernÃ­ch zaÅ™Ã­zenÃ­ se zdÃ¡, Å¾e tyto prahy regulujÃ­ automaticky.
 .br
-U moderních karet mù¾e tento parametr ovládat práh pøedání (handover/roaming
-threshold) - nejni¾¹í úroveò signálu pøi které hardware je¹tì zùstane asociováno se
-souèasnım pøístupovım bodem. Pokud úroveò signálu poklesne pod tuto hodnotu, 
-zaène karta hledat novı/lep¹í pøístupovı bod.
+U modernÃ­ch karet mÅ¯Å¾e tento parametr ovlÃ¡dat prÃ¡h pÅ™edÃ¡nÃ­ (handover/roaming
+threshold) - nejniÅ¾Å¡Ã­ ÃºroveÅˆ signÃ¡lu pÅ™i kterÃ© hardware jeÅ¡tÄ› zÅ¯stane asociovÃ¡no se
+souÄasnÃ½m pÅ™Ã­stupovÃ½m bodem. Pokud ÃºroveÅˆ signÃ¡lu poklesne pod tuto hodnotu, 
+zaÄne karta hledat novÃ½/lepÅ¡Ã­ pÅ™Ã­stupovÃ½ bod.
 .br
-.B Pøíklad:
+.B PÅ™Ã­klad:
 .br
 .I "	iwconfig eth0 sens -80"
 .TP
 .B mode
-nastaví pracovní re¾im zaøízení, co¾ závisí na topologii sítì.
-Re¾im mù¾e bıt
+nastavÃ­ pracovnÃ­ reÅ¾im zaÅ™Ã­zenÃ­, coÅ¾ zÃ¡visÃ­ na topologii sÃ­tÄ›.
+ReÅ¾im mÅ¯Å¾e bÃ½t
 .I Ad-Hoc
-(sí» slo¾ená pouze z jedné buòky a bez pøístupového bodu),
+(sÃ­Å¥ sloÅ¾enÃ¡ pouze z jednÃ© buÅˆky a bez pÅ™Ã­stupovÃ©ho bodu),
 .I Managed
-(node se pøipojuje do sítì slo¾ené z mnoha pøístupovıch bodù, s roamingem),
+(node se pÅ™ipojuje do sÃ­tÄ› sloÅ¾enÃ© z mnoha pÅ™Ã­stupovÃ½ch bodÅ¯, s roamingem),
 .I Master
-(node je synchronisation master nebo slou¾í jako pøístupovı bod),
+(node je synchronisation master nebo slouÅ¾Ã­ jako pÅ™Ã­stupovÃ½ bod),
 .I Repeater
-(node pøedává pakety mezi ostatními bezdrátovımi nody),
+(node pÅ™edÃ¡vÃ¡ pakety mezi ostatnÃ­mi bezdrÃ¡tovÃ½mi nody),
 .I Secondary
-(node slou¾í jako zálo¾ní master/repeater),
+(node slouÅ¾Ã­ jako zÃ¡loÅ¾nÃ­ master/repeater),
 .I Monitor
-(node není asociován s ¾ádnou buòkou a pasivnì monitoruje pakety na frekvenci) nebo
+(node nenÃ­ asociovÃ¡n s Å¾Ã¡dnou buÅˆkou a pasivnÄ› monitoruje pakety na frekvenci) nebo
 .IR Auto .
 .br
-.B pøíklad:
+.B pÅ™Ã­klad:
 .br
 .I "	iwconfig eth0 mode Managed"
 .br
 .I "	iwconfig eth0 mode Ad-Hoc"
 .TP
 .B ap
-Naøídí kartì pøipojit se k pøístupovému bodu urèenému adresou,
-pokud je to mo¾né. Pokud se kvalita spojení pøíli¹ sní¾í,
-mù¾e se ovladaè vrátit do automatického módu (karta vybere
-nejlep¹í pøístupovı bod v dosahu).
+NaÅ™Ã­dÃ­ kartÄ› pÅ™ipojit se k pÅ™Ã­stupovÃ©mu bodu urÄenÃ©mu adresou,
+pokud je to moÅ¾nÃ©. Pokud se kvalita spojenÃ­ pÅ™Ã­liÅ¡ snÃ­Å¾Ã­,
+mÅ¯Å¾e se ovladaÄ vrÃ¡tit do automatickÃ©ho mÃ³du (karta vybere
+nejlepÅ¡Ã­ pÅ™Ã­stupovÃ½ bod v dosahu).
 .br
-Je také mo¾né pou¾ít
+Je takÃ© moÅ¾nÃ© pouÅ¾Ã­t
 .I off
-k opìtovnému zapnutí automatického módu beze zmìny souèasného pøístupového bodu
+k opÄ›tovnÃ©mu zapnutÃ­ automatickÃ©ho mÃ³du beze zmÄ›ny souÄasnÃ©ho pÅ™Ã­stupovÃ©ho bodu
 nebo
 .I any
-èi
+Äi
 .I auto
-k vynucení opìtovné asociace karty s momentálnì nejlep¹ím pøístupovım bodem.
+k vynucenÃ­ opÄ›tovnÃ© asociace karty s momentÃ¡lnÄ› nejlepÅ¡Ã­m pÅ™Ã­stupovÃ½m bodem.
 .br
-.B Pøíklad :
+.B PÅ™Ã­klad :
 .br
 .I "	iwconfig eth0 ap 00:60:1D:01:23:45"
 .br
@@ -185,32 +185,32 @@ k vynucení opìtovné asociace karty s momentálnì nejlep¹ím pøístupovım bodem.
 .I "	iwconfig eth0 ap off"
 .TP
 .BR nick [name]
-Nastaví pøezdívku neboli station name. Nìkteré 802.11 produkty ji definují,
-ale co se tıká protokolù (MAC, IP, TCP), není pou¾ívána a pøi konfiguraci je
-zcela nepotøebná. Pou¾ívají ji pouze nìkteré diagnostické nástroje.
+NastavÃ­ pÅ™ezdÃ­vku neboli station name. NÄ›kterÃ© 802.11 produkty ji definujÃ­,
+ale co se tÃ½kÃ¡ protokolÅ¯ (MAC, IP, TCP), nenÃ­ pouÅ¾Ã­vÃ¡na a pÅ™i konfiguraci je
+zcela nepotÅ™ebnÃ¡. PouÅ¾Ã­vajÃ­ ji pouze nÄ›kterÃ© diagnostickÃ© nÃ¡stroje.
 .br
-.B Pøíklad:
+.B PÅ™Ã­klad:
 .br
 .I "	iwconfig eth0 nickname ""Muj linuxovy node""
 .TP
 .BR rate / bit [rate]
-U karet, které podporují více pøenosovıch rychlostí, nastaví rychlost pøenosu v b/s.
-Rychlost pøenosu je rychlost, kterou jsou bity pøená¹eny médiem,
-rychlost pro u¾ivatele je ni¾¹í kvùli sdílení média a rùzné re¾ii.
+U karet, kterÃ© podporujÃ­ vÃ­ce pÅ™enosovÃ½ch rychlostÃ­, nastavÃ­ rychlost pÅ™enosu v b/s.
+Rychlost pÅ™enosu je rychlost, kterou jsou bity pÅ™enÃ¡Å¡eny mÃ©diem,
+rychlost pro uÅ¾ivatele je niÅ¾Å¡Ã­ kvÅ¯li sdÃ­lenÃ­ mÃ©dia a rÅ¯znÃ© reÅ¾ii.
 .br
-Je mo¾né pøipojit k hodnotì pøíponu k, M nebo G (dekadickı násobitel:
-10^3, 10^6 a 10^9 b/s), nebo doplnit dostateènı poèet nul. Vıznam hodnoty ni¾¹í ne¾
-1000 závisí na pou¾ité kartì, obvykle znamená index v seznamu pøenosovıch rychlostí.
-Je mo¾né pou¾ít
+Je moÅ¾nÃ© pÅ™ipojit k hodnotÄ› pÅ™Ã­ponu k, M nebo G (dekadickÃ½ nÃ¡sobitel:
+10^3, 10^6 a 10^9 b/s), nebo doplnit dostateÄnÃ½ poÄet nul. VÃ½znam hodnoty niÅ¾Å¡Ã­ neÅ¾
+1000 zÃ¡visÃ­ na pouÅ¾itÃ© kartÄ›, obvykle znamenÃ¡ index v seznamu pÅ™enosovÃ½ch rychlostÃ­.
+Je moÅ¾nÃ© pouÅ¾Ã­t
 .I auto
-ke zvolení re¾imu automatické pøenosové rychlosti (ústup na ni¾¹í rychlost v za¹umìnıch
-kanálech), co¾ je u vìt¹iny karet vıchozí nastavení, a
+ke zvolenÃ­ reÅ¾imu automatickÃ© pÅ™enosovÃ© rychlosti (Ãºstup na niÅ¾Å¡Ã­ rychlost v zaÅ¡umÄ›nÃ½ch
+kanÃ¡lech), coÅ¾ je u vÄ›tÅ¡iny karet vÃ½chozÃ­ nastavenÃ­, a
 .I fixed
-k návratu k pevnému nastavení. Pokud je urèena pøenosová rychlost a 
+k nÃ¡vratu k pevnÃ©mu nastavenÃ­. Pokud je urÄena pÅ™enosovÃ¡ rychlost a 
 .IR auto ,
-mù¾e ovladaè pou¾ít v¹echny pøenosové rychlosti rovné této hodnotì a ni¾¹í.
+mÅ¯Å¾e ovladaÄ pouÅ¾Ã­t vÅ¡echny pÅ™enosovÃ© rychlosti rovnÃ© tÃ©to hodnotÄ› a niÅ¾Å¡Ã­.
 .br
-.B Pøíklady:
+.B PÅ™Ã­klady:
 .br
 .I "	iwconfig eth0 rate 11M"
 .br
@@ -219,71 +219,71 @@ mù¾e ovladaè pou¾ít v¹echny pøenosové rychlosti rovné této hodnotì a ni¾¹í.
 .I "	iwconfig eth0 rate 5.5M auto"
 .TP
 .BR rts [_threshold]
-RTS/CTS pøidá handshake pøed ka¾dım pøenosem paketù, aby se zajistilo,
-¾e je kanál volnı. To zvı¹í re¾ii, ale také vıkon v pøípadì skrytıch nodù
-nebo velkého poètu aktivních nodù. Tento parametr nastavuje velikost nejmen¹ího 
-paketu, pro kterı node vysílá RTS; hodnota rovná maximální velikosti paketu
-tento mechanismus vypne. Je také mo¾né nastavit tento parametr na
+RTS/CTS pÅ™idÃ¡ handshake pÅ™ed kaÅ¾dÃ½m pÅ™enosem paketÅ¯, aby se zajistilo,
+Å¾e je kanÃ¡l volnÃ½. To zvÃ½Å¡Ã­ reÅ¾ii, ale takÃ© vÃ½kon v pÅ™Ã­padÄ› skrytÃ½ch nodÅ¯
+nebo velkÃ©ho poÄtu aktivnÃ­ch nodÅ¯. Tento parametr nastavuje velikost nejmenÅ¡Ã­ho 
+paketu, pro kterÃ½ node vysÃ­lÃ¡ RTS; hodnota rovnÃ¡ maximÃ¡lnÃ­ velikosti paketu
+tento mechanismus vypne. Je takÃ© moÅ¾nÃ© nastavit tento parametr na
 .IR auto ", " fixed " nebo " off .
 .br
-.B Pøíklady:
+.B PÅ™Ã­klady:
 .br
 .I "	iwconfig eth0 rts 250"
 .br
 .I "	iwconfig eth0 rts off"
 .TP
 .BR frag [mentation_threshold]
-Fragmentace dovoluje rozdìlit IP paket na dávku nìkolika men¹ích èástí
-pøenesenıch médiem. To ve vìt¹inì pøípadù zvìt¹í re¾ii, ale ve velmi za¹umìnìm
-prostøedí sní¾í ztráty zpùsobené chybami a umo¾ní paketùm projít
-pøi zaru¹ení. Tento parametr nastaví maximální velikost fragmentu; hodnota
-rovná maximální velikosti paketu tento mechanismus vypne. Je také
-mo¾né nastavit tento mechanismus na
+Fragmentace dovoluje rozdÄ›lit IP paket na dÃ¡vku nÄ›kolika menÅ¡Ã­ch ÄÃ¡stÃ­
+pÅ™enesenÃ½ch mÃ©diem. To ve vÄ›tÅ¡inÄ› pÅ™Ã­padÅ¯ zvÄ›tÅ¡Ã­ reÅ¾ii, ale ve velmi zaÅ¡umÄ›nÄ›m
+prostÅ™edÃ­ snÃ­Å¾Ã­ ztrÃ¡ty zpÅ¯sobenÃ© chybami a umoÅ¾nÃ­ paketÅ¯m projÃ­t
+pÅ™i zaruÅ¡enÃ­. Tento parametr nastavÃ­ maximÃ¡lnÃ­ velikost fragmentu; hodnota
+rovnÃ¡ maximÃ¡lnÃ­ velikosti paketu tento mechanismus vypne. Je takÃ©
+moÅ¾nÃ© nastavit tento mechanismus na
 .IR auto ", " fixed " nebo " off .
 .br
-.B Pøíklady:
+.B PÅ™Ã­klady:
 .br
 .I "	iwconfig eth0 frag 512"
 .br
 .I "	iwconfig eth0 frag off"
 .TP
 .BR key / enc [ryption]
-Pou¾ívá se k nastavení ¹ifrovacích klíèù a bezpeènostního re¾imu.
+PouÅ¾Ã­vÃ¡ se k nastavenÃ­ Å¡ifrovacÃ­ch klÃ­ÄÅ¯ a bezpeÄnostnÃ­ho reÅ¾imu.
 .br
-Pro nastavení aktuálního ¹ifrovacího klíèe se pouze zadá klíè v hexadecimální podobì jako
+Pro nastavenÃ­ aktuÃ¡lnÃ­ho Å¡ifrovacÃ­ho klÃ­Äe se pouze zadÃ¡ klÃ­Ä v hexadecimÃ¡lnÃ­ podobÄ› jako
 .IR XXXX-XXXX-XXXX-XXXX " nebo " XXXXXXXX .
-Pro nastavení jiného ne¾ aktuálního klíèe pøidejte pøed nebo za vlastní klíè
+Pro nastavenÃ­ jinÃ©ho neÅ¾ aktuÃ¡lnÃ­ho klÃ­Äe pÅ™idejte pÅ™ed nebo za vlastnÃ­ klÃ­Ä
 .I [index]
-(tím se nezmìní aktuální klíè). Je také mo¾né zadat klíè
-jako øetìzec ASCII znakù pomocí pøedpony
+(tÃ­m se nezmÄ›nÃ­ aktuÃ¡lnÃ­ klÃ­Ä). Je takÃ© moÅ¾nÃ© zadat klÃ­Ä
+jako Å™etÄ›zec ASCII znakÅ¯ pomocÃ­ pÅ™edpony
 .I s:
-. Passphrase není v souèasnosti podporovaná.
+. Passphrase nenÃ­ v souÄasnosti podporovanÃ¡.
 .br
-Pro urèení, kterı klíè má bıt aktivní, se vlo¾í
+Pro urÄenÃ­, kterÃ½ klÃ­Ä mÃ¡ bÃ½t aktivnÃ­, se vloÅ¾Ã­
 .I [index]
-(bez zadání hodnoty klíèe).
+(bez zadÃ¡nÃ­ hodnoty klÃ­Äe).
 .br
 .IR off " a " on
-Vypnou a znovu zapnou ¹ifrování.
+Vypnou a znovu zapnou Å¡ifrovÃ¡nÃ­.
 .br
-Bezpeènostní re¾im mù¾e bıt
+BezpeÄnostnÃ­ reÅ¾im mÅ¯Å¾e bÃ½t
 .I open
-(otevøenı) nebo
+(otevÅ™enÃ½) nebo
 .IR restricted ,
-(uzavøenı) a jeho vıznam závisí na pou¾ité kartì. Vìt¹ina karet nepou¾ívá v
+(uzavÅ™enÃ½) a jeho vÃ½znam zÃ¡visÃ­ na pouÅ¾itÃ© kartÄ›. VÄ›tÅ¡ina karet nepouÅ¾Ã­vÃ¡ v
 .I open
-(otevøeném) re¾imu ¾ádnou autentizaci a karta mù¾e také pøijímat
-neza¹ifrované relace, zatímco v
+(otevÅ™enÃ©m) reÅ¾imu Å¾Ã¡dnou autentizaci a karta mÅ¯Å¾e takÃ© pÅ™ijÃ­mat
+nezaÅ¡ifrovanÃ© relace, zatÃ­mco v
 .I restricted
-(uzavøeném) re¾imu jsou akceptovány pouze za¹ifrované relace a karta pou¾ije autentizaci,
+(uzavÅ™enÃ©m) reÅ¾imu jsou akceptovÃ¡ny pouze zaÅ¡ifrovanÃ© relace a karta pouÅ¾ije autentizaci,
 pokud je k dispozici.
 .br
-Pokud je tøeba nastavit více klíèù, nebo nastavit klíè a urèit aktivní klíè,
-je nutné pou¾ít více pøepínaèù
+Pokud je tÅ™eba nastavit vÃ­ce klÃ­ÄÅ¯, nebo nastavit klÃ­Ä a urÄit aktivnÃ­ klÃ­Ä,
+je nutnÃ© pouÅ¾Ã­t vÃ­ce pÅ™epÃ­naÄÅ¯
 .B key
-. Parametry mohou bıt v jakémkoliv poøadí, poslední má pøednost.
+. Parametry mohou bÃ½t v jakÃ©mkoliv poÅ™adÃ­, poslednÃ­ mÃ¡ pÅ™ednost.
 .br
-.B Pøíklady:
+.B PÅ™Ã­klady:
 .br
 .I "	iwconfig eth0 key 0123-4567-89"
 .br
@@ -302,29 +302,29 @@ je nutné pou¾ít více pøepínaèù
 .I "	iwconfig eth0 key 01-23 key 45-67 [4] key [4]"
 .TP
 .BR power
-Nastavuje re¾im øízení spotøeby a jeho parametry.
+Nastavuje reÅ¾im Å™Ã­zenÃ­ spotÅ™eby a jeho parametry.
 .br
-Pro nastavení èasu mezi probuzeními se vlo¾í
+Pro nastavenÃ­ Äasu mezi probuzenÃ­mi se vloÅ¾Ã­
 .IR "period `hodnota'" .
-Pro nastavení prodlevy pøed návratem do spánku se vlo¾í
+Pro nastavenÃ­ prodlevy pÅ™ed nÃ¡vratem do spÃ¡nku se vloÅ¾Ã­
 .IR "timeout `hodnota'" .
-Je také mo¾né pøidat modifikátory
+Je takÃ© moÅ¾nÃ© pÅ™idat modifikÃ¡tory
 .IR min " a " max
-. Hodnoty znamenají poèet sekund, pro urèení v milisekundách
-nebo mikrosekundách se pou¾ije pøípona m nebo u. Nìkdy jsou
-tyto hodnoty bez jednotek (poèet období mezi beacons a podobnì).
+. Hodnoty znamenajÃ­ poÄet sekund, pro urÄenÃ­ v milisekundÃ¡ch
+nebo mikrosekundÃ¡ch se pouÅ¾ije pÅ™Ã­pona m nebo u. NÄ›kdy jsou
+tyto hodnoty bez jednotek (poÄet obdobÃ­ mezi beacons a podobnÄ›).
 .br
 .IR off " a " on
-vypne a novu zapne øízení spotøeby. Je také mo¾né nastavit
-re¾im øízení spotøeby na
+vypne a novu zapne Å™Ã­zenÃ­ spotÅ™eby. Je takÃ© moÅ¾nÃ© nastavit
+reÅ¾im Å™Ã­zenÃ­ spotÅ™eby na
 .I all
-(pøijímá v¹echny pakety),
+(pÅ™ijÃ­mÃ¡ vÅ¡echny pakety),
 .I unicast
-(pøijímá pouze unicast pakety, zahazuje multicast a broadcast) a
+(pÅ™ijÃ­mÃ¡ pouze unicast pakety, zahazuje multicast a broadcast) a
 .I multicast
-(pøijímá pouze multicast a broadcast, zahazuje unicast pakety).
+(pÅ™ijÃ­mÃ¡ pouze multicast a broadcast, zahazuje unicast pakety).
 .br
-.B Pøíklady:
+.B PÅ™Ã­klady:
 .br
 .I "	iwconfig eth0 power period 2"
 .br
@@ -337,21 +337,21 @@ re¾im øízení spotøeby na
 .I "	iwconfig eth0 power min period 2 power max period 4"
 .TP
 .BR txpower
-U karet podporujících rozdílné vysílací vıkony nastavuje vysílací vıkon v dBm. Je-li dán vıkon 
+U karet podporujÃ­cÃ­ch rozdÃ­lnÃ© vysÃ­lacÃ­ vÃ½kony nastavuje vysÃ­lacÃ­ vÃ½kon v dBm. Je-li dÃ¡n vÃ½kon 
 .I W
-ve Wattech, je vıkon v dBm roven
+ve Wattech, je vÃ½kon v dBm roven
 .IR "P = 30 + 10.log(W)" .
-Pokud je hodnota doplnìna pøíponou
+Pokud je hodnota doplnÄ›na pÅ™Ã­ponou
 .IR mW ,
-je automaticky pøevedena na dBm.
+je automaticky pÅ™evedena na dBm.
 .br
-Navíc volby 
+NavÃ­c volby 
 .IR on " a " off
-povolí a zaká¾ou vysílání, 
+povolÃ­ a zakÃ¡Å¾ou vysÃ­lÃ¡nÃ­, 
 .IR auto " a " fixed
-povolí a zaká¾ou mo¾nost mìnit vıkon (pokud je tato vlastnost k dispozici).
+povolÃ­ a zakÃ¡Å¾ou moÅ¾nost mÄ›nit vÃ½kon (pokud je tato vlastnost k dispozici).
 .br
-.B Pøíklady:
+.B PÅ™Ã­klady:
 .br
 .I "	iwconfig eth0 txpower 15"
 .br
@@ -362,26 +362,26 @@ povolí a zaká¾ou mo¾nost mìnit vıkon (pokud je tato vlastnost k dispozici).
 .I "	iwconfig eth0 txpower off"
 .TP
 .BR retry
-Vìt¹ina karet umí MAC retransmisi a nìkteré umo¾òují nastavit
-chování tohoto mechanismu.
+VÄ›tÅ¡ina karet umÃ­ MAC retransmisi a nÄ›kterÃ© umoÅ¾ÅˆujÃ­ nastavit
+chovÃ¡nÃ­ tohoto mechanismu.
 .br
-pro nastavení maximálního poètu pokusù o zaslání se zadá
+pro nastavenÃ­ maximÃ¡lnÃ­ho poÄtu pokusÅ¯ o zaslÃ¡nÃ­ se zadÃ¡
 .IR "limit `hodnota'" .
-Toto je absolutní hodnota (bez jednotky).
-Pro nastavení nejdel¹ího období, ve kterém se má MAC pokou¹et o zaslání, se zadá
+Toto je absolutnÃ­ hodnota (bez jednotky).
+Pro nastavenÃ­ nejdelÅ¡Ã­ho obdobÃ­, ve kterÃ©m se mÃ¡ MAC pokouÅ¡et o zaslÃ¡nÃ­, se zadÃ¡
 .IR "lifetime `hodnota'" .
-Hodnoty znamenají poèet sekund, pro urèení v milisekundách
-nebo mikrosekundách se pou¾ije pøípona m nebo u.
+Hodnoty znamenajÃ­ poÄet sekund, pro urÄenÃ­ v milisekundÃ¡ch
+nebo mikrosekundÃ¡ch se pouÅ¾ije pÅ™Ã­pona m nebo u.
 .br
-je také mo¾né pøidat modifikátory
+je takÃ© moÅ¾nÃ© pÅ™idat modifikÃ¡tory
 .IR min " a " max
-. Pokud karta podporuje automatickı re¾im, urèují tyto modifikátory rozmezí pro limit nebo lifetime.
-Nìkteré karty definují rùzné hodnoty v závislosti na velikosti
-paketù, napø. v 802.11 urèuje
+. Pokud karta podporuje automatickÃ½ reÅ¾im, urÄujÃ­ tyto modifikÃ¡tory rozmezÃ­ pro limit nebo lifetime.
+NÄ›kterÃ© karty definujÃ­ rÅ¯znÃ© hodnoty v zÃ¡vislosti na velikosti
+paketÅ¯, napÅ™. v 802.11 urÄuje
 .I min limit
-tzv. "short retry limit" - limit pro pakety, na které není aplikováno RTS/CTS.
+tzv. "short retry limit" - limit pro pakety, na kterÃ© nenÃ­ aplikovÃ¡no RTS/CTS.
 .br
-.B Pøíklady:
+.B PÅ™Ã­klady:
 .br
 .I "	iwconfig eth0 retry 16"
 .br
@@ -390,124 +390,124 @@ tzv. "short retry limit" - limit pro pakety, na které není aplikováno RTS/CTS.
 .I "	iwconfig eth0 retry min limit 8"
 .TP
 .BR commit
-Nìkteré karty nemusí provést zmìny zadané pøes Wireless Extensions
-okam¾itì (mohou èekat na nashromá¾dìní zmìn a pøijmout je
-a¾ kdy¾ je karta aktivována pomocí ifconfig). Tento pøíkaz (pokud
-je dostupnı) pøinutí kartu k pøijetí v¹ech nevyøízenıch zmìn.
+NÄ›kterÃ© karty nemusÃ­ provÃ©st zmÄ›ny zadanÃ© pÅ™es Wireless Extensions
+okamÅ¾itÄ› (mohou Äekat na nashromÃ¡Å¾dÄ›nÃ­ zmÄ›n a pÅ™ijmout je
+aÅ¾ kdyÅ¾ je karta aktivovÃ¡na pomocÃ­ ifconfig). Tento pÅ™Ã­kaz (pokud
+je dostupnÃ½) pÅ™inutÃ­ kartu k pÅ™ijetÃ­ vÅ¡ech nevyÅ™Ã­zenÃ½ch zmÄ›n.
 .br
-To není vìt¹inou potøeba, proto¾e karta èasem zmìny pøijme, ale mù¾e to
-bıt u¾iteèné pøi ladìní.
+To nenÃ­ vÄ›tÅ¡inou potÅ™eba, protoÅ¾e karta Äasem zmÄ›ny pÅ™ijme, ale mÅ¯Å¾e to
+bÃ½t uÅ¾iteÄnÃ© pÅ™i ladÄ›nÃ­.
 .\"
 .\" DISPLAY part
 .\"
-.SH ZOBRAZENÍ
-Pro ka¾dé zaøízení, které podporuje wireless extensions, zobrazí
+.SH ZOBRAZENÃ
+Pro kaÅ¾dÃ© zaÅ™Ã­zenÃ­, kterÃ© podporuje wireless extensions, zobrazÃ­
 .I iwconfig
-název pou¾itého
+nÃ¡zev pouÅ¾itÃ©ho
 .B MAC protokolu
- (název zaøízení u proprietárních protokolù),
+ (nÃ¡zev zaÅ™Ã­zenÃ­ u proprietÃ¡rnÃ­ch protokolÅ¯),
 .B ESSID
 (Network Name),
 .BR NWID ,
 .B frekvenci
-(nebo kanál),
+(nebo kanÃ¡l),
 .BR sensitivity 
 (citlivost),
 .B mode
-(pracovní re¾im), 
+(pracovnÃ­ reÅ¾im), 
 .B Access Point
-(adresu pøístupového bodu),
+(adresu pÅ™Ã­stupovÃ©ho bodu),
 .B bit-rate
-(pøenosovou rychlost),
+(pÅ™enosovou rychlost),
 .BR "RTS threshold"
-(práh RTS), 
+(prÃ¡h RTS), 
 .BR "fragmentation threshold"
-(práh fragmentace),
+(prÃ¡h fragmentace),
 .B encryption key
-(¹ifrovací klíè) a nastavení
+(Å¡ifrovacÃ­ klÃ­Ä) a nastavenÃ­
 .B power management
-(øízení spotøeby)(pokud je k dispozici).
+(Å™Ã­zenÃ­ spotÅ™eby)(pokud je k dispozici).
 .PP
-Zobrazené parametry mají stejnı vıznam a hodnoty jako parametry, 
-které mohou bıt nastaveny, pro jejich podrobnìj¹í vysvìtlení se prosím 
-obra»te se na pøedchozí èást.
+ZobrazenÃ© parametry majÃ­ stejnÃ½ vÃ½znam a hodnoty jako parametry, 
+kterÃ© mohou bÃ½t nastaveny, pro jejich podrobnÄ›jÅ¡Ã­ vysvÄ›tlenÃ­ se prosÃ­m 
+obraÅ¥te se na pÅ™edchozÃ­ ÄÃ¡st.
 .br
-Nìkteré parametry jsou zobrazeny pouze ve své krátké/zkrácené podobì
-(napø. ¹ifrování). Je mo¾né pou¾ít
+NÄ›kterÃ© parametry jsou zobrazeny pouze ve svÃ© krÃ¡tkÃ©/zkrÃ¡cenÃ© podobÄ›
+(napÅ™. Å¡ifrovÃ¡nÃ­). Je moÅ¾nÃ© pouÅ¾Ã­t
 .IR iwlist (8)
-k získání detailù.
+k zÃ­skÃ¡nÃ­ detailÅ¯.
 .br
-Nìkteré parametry mají dva re¾imy (napø. pøenosová rychlost). Pokud
+NÄ›kterÃ© parametry majÃ­ dva reÅ¾imy (napÅ™. pÅ™enosovÃ¡ rychlost). Pokud
 hodnotu uvozuje
 .RB ` = ',
-znamená to, ¾e parametr je pevnı a danı touto hodnotou, pokud
+znamenÃ¡ to, Å¾e parametr je pevnÃ½ a danÃ½ touto hodnotou, pokud
 ji uvozuje
 .RB ` : ',
-je parametr v automatickém re¾imu a je zobrazena aktuální hodnota (a
-mù¾e se zmìnit).
+je parametr v automatickÃ©m reÅ¾imu a je zobrazena aktuÃ¡lnÃ­ hodnota (a
+mÅ¯Å¾e se zmÄ›nit).
 .TP
 .BR "Access Point" / Cell
-Adresa rovná 00:00:00:00:00:00 znamená, ¾e se karta nedokázala asociovat
-s pøístupovım bodem (nejspí¹e problém v nastavení).
+Adresa rovnÃ¡ 00:00:00:00:00:00 znamenÃ¡, Å¾e se karta nedokÃ¡zala asociovat
+s pÅ™Ã­stupovÃ½m bodem (nejspÃ­Å¡e problÃ©m v nastavenÃ­).
 Parametr
 .B Access Point
 bude zobrazen jako
 .B Cell
-v re¾imu ad-hoc (ze zøejmıch dùvodù), ale jinak znamená to samé.
+v reÅ¾imu ad-hoc (ze zÅ™ejmÃ½ch dÅ¯vodÅ¯), ale jinak znamenÃ¡ to samÃ©.
 .PP
 Pokud existuje
 .IR "/proc/net/wireless" ,
 .I iwconfig
-se také pokusí zobrazit jeho obsah. Nicménì tyto hodnoty závisí na
-ovladaèi a zvlá¹tnostech hardware, tak¾e pro jejich správnou interpretaci je nutné obrátit se na
-dokumentaci ovladaèe.
+se takÃ© pokusÃ­ zobrazit jeho obsah. NicmÃ©nÄ› tyto hodnoty zÃ¡visÃ­ na
+ovladaÄi a zvlÃ¡Å¡tnostech hardware, takÅ¾e pro jejich sprÃ¡vnou interpretaci je nutnÃ© obrÃ¡tit se na
+dokumentaci ovladaÄe.
 .TP
 .B Link quality
-Celková kvalita spoje. Mù¾e bıt zalo¾ena na úrovni ru¹ení 
-èi interference, poètu chyb na úrovni bitù nebo rámcù, síle pøijímaného
-signálu, synchronizaci èasování nebo dal¹ích hardwarovıch mìøeních. Je to
-celková hodnota a zcela zále¾í na ovladaèi a hardware.
+CelkovÃ¡ kvalita spoje. MÅ¯Å¾e bÃ½t zaloÅ¾ena na Ãºrovni ruÅ¡enÃ­ 
+Äi interference, poÄtu chyb na Ãºrovni bitÅ¯ nebo rÃ¡mcÅ¯, sÃ­le pÅ™ijÃ­manÃ©ho
+signÃ¡lu, synchronizaci ÄasovÃ¡nÃ­ nebo dalÅ¡Ã­ch hardwarovÃ½ch mÄ›Å™enÃ­ch. Je to
+celkovÃ¡ hodnota a zcela zÃ¡leÅ¾Ã­ na ovladaÄi a hardware.
 .TP
 .B Signal level
-Received signal strength (RSSI - indikátor síly pøijímaného signálu). 
-Mù¾e bıt v libovolnıch jednotkách nebo dBm,
+Received signal strength (RSSI - indikÃ¡tor sÃ­ly pÅ™ijÃ­manÃ©ho signÃ¡lu). 
+MÅ¯Å¾e bÃ½t v libovolnÃ½ch jednotkÃ¡ch nebo dBm,
 .I iwconfig
-pou¾ívá informace z ovladaèe k interpretaci surovıch dat v
+pouÅ¾Ã­vÃ¡ informace z ovladaÄe k interpretaci surovÃ½ch dat v
 .I /proc/net/wireless
-a zobrazení správné jednotky nebo maximální hodnoty (pomocí 8 bitovıch vıpoètù). V
+a zobrazenÃ­ sprÃ¡vnÃ© jednotky nebo maximÃ¡lnÃ­ hodnoty (pomocÃ­ 8 bitovÃ½ch vÃ½poÄtÅ¯). V
 .I Ad-Hoc
-re¾imu mù¾e bıt nedefinovaná a mìl by bıt pou¾it 
+reÅ¾imu mÅ¯Å¾e bÃ½t nedefinovanÃ¡ a mÄ›l by bÃ½t pouÅ¾it 
 .IR iwspy .
 .TP
 .B Noise level
-Úroveò ¹umu pozadí (kdy¾ není pøená¹en ¾ádnı paket). Platí stejné poznámky 
+ÃšroveÅˆ Å¡umu pozadÃ­ (kdyÅ¾ nenÃ­ pÅ™enÃ¡Å¡en Å¾Ã¡dnÃ½ paket). PlatÃ­ stejnÃ© poznÃ¡mky 
 jako pro
 .BR "Signal level" .
 .TP
 .B Rx invalid nwid
-Poèet pøijatıch paketù s odli¹nım NWID nebo ESSID. Pou¾ívá se 
-k detekci problémù v nastavení nebo existence sousední sítì
-(na stejné frekvuenci).
+PoÄet pÅ™ijatÃ½ch paketÅ¯ s odliÅ¡nÃ½m NWID nebo ESSID. PouÅ¾Ã­vÃ¡ se 
+k detekci problÃ©mÅ¯ v nastavenÃ­ nebo existence sousednÃ­ sÃ­tÄ›
+(na stejnÃ© frekvuenci).
 .TP
 .B Rx invalid crypt
-Poèet paketù, které hardware nedokázal de¹ifrovat. Mù¾e indikovat
-neplatné nastavení ¹ifrování.
+PoÄet paketÅ¯, kterÃ© hardware nedokÃ¡zal deÅ¡ifrovat. MÅ¯Å¾e indikovat
+neplatnÃ© nastavenÃ­ Å¡ifrovÃ¡nÃ­.
 .TP
 .B Rx invalid frag
-Poèet paketù, pro které hardware nedokázal správnì znovu sestavit
-jednotlivé fragmenty na fyzické vrstvì (nejspí¹e jeden chybìl).
+PoÄet paketÅ¯, pro kterÃ© hardware nedokÃ¡zal sprÃ¡vnÄ› znovu sestavit
+jednotlivÃ© fragmenty na fyzickÃ© vrstvÄ› (nejspÃ­Å¡e jeden chybÄ›l).
 .TP
 .B Tx excessive retries
-Poèet paketù, které hardware nedokázal odeslat. Vìt¹ina MAC
-protokolù zkusí poslat paket nìkolikrát, ne¾ to vzdá.
+PoÄet paketÅ¯, kterÃ© hardware nedokÃ¡zal odeslat. VÄ›tÅ¡ina MAC
+protokolÅ¯ zkusÃ­ poslat paket nÄ›kolikrÃ¡t, neÅ¾ to vzdÃ¡.
 .TP
 .B Invalid misc
-Ostatní pakety ztracené v souvislosti s urèitımi bezdrátovımi operacemi.
+OstatnÃ­ pakety ztracenÃ© v souvislosti s urÄitÃ½mi bezdrÃ¡tovÃ½mi operacemi.
 .TP
 .B Missed beacon
-Poèet pravidelnıch beacons z buòky nebo pøístupového bodu, které nebyly zachyceny.
-Beacons jsou vysílány v pravidelnıch intervalech pro udr¾ení koordinace a
-pokud nejsou zachyceny, vìt¹inou to znamená, ¾e je karta mimo dosah.
+PoÄet pravidelnÃ½ch beacons z buÅˆky nebo pÅ™Ã­stupovÃ©ho bodu, kterÃ© nebyly zachyceny.
+Beacons jsou vysÃ­lÃ¡ny v pravidelnÃ½ch intervalech pro udrÅ¾enÃ­ koordinace a
+pokud nejsou zachyceny, vÄ›tÅ¡inou to znamenÃ¡, Å¾e je karta mimo dosah.
 .\"
 .\" AUTHOR part
 .\"
@@ -516,8 +516,8 @@ Jean Tourrilhes \- jt@hpl.hp.com
 .\"
 .\" TRANSLATION part
 .\"
-.SH PØEKLAD
-Pavel Heimlich \- tropikhajma@seznam.cz, bøezen 2005 (wireless_tools.28pre4).
+.SH PÅ˜EKLAD
+Pavel Heimlich \- tropikhajma@seznam.cz, bÅ™ezen 2005 (wireless_tools.28pre4).
 .\"
 .\" FILES part
 .\"
@@ -526,7 +526,7 @@ Pavel Heimlich \- tropikhajma@seznam.cz, bøezen 2005 (wireless_tools.28pre4).
 .\"
 .\" SEE ALSO part
 .\"
-.SH DAL©Í INFORMACE
+.SH DALÅ Ã INFORMACE
 .BR ifconfig (8),
 .BR iwspy (8),
 .BR iwlist (8),

--- a/wireless_tools/cs/iwevent.8
+++ b/wireless_tools/cs/iwevent.8
@@ -1,12 +1,12 @@
 .\" Jean Tourrilhes - HPL - 2002 - 2004
 .\" iwevent.8
 .\"
-.TH IWEVENT 8 "23.èerven 2004" "net-tools" "Linux - Manuál programátora"
+.TH IWEVENT 8 "23.Äerven 2004" "net-tools" "Linux - ManuÃ¡l programÃ¡tora"
 .\"
 .\" NAME part
 .\"
-.SH JMÉNO
-iwevent \- Zobrazí bezdrátové události vyvolané ovladaèi a zmìnami nastavení
+.SH JMÃ‰NO
+iwevent \- ZobrazÃ­ bezdrÃ¡tovÃ© udÃ¡losti vyvolanÃ© ovladaÄi a zmÄ›nami nastavenÃ­
 .\"
 .\" SYNOPSIS part
 .\"
@@ -18,25 +18,25 @@ iwevent \- Zobrazí bezdrátové události vyvolané ovladaèi a zmìnami nastavení
 .\"
 .SH POPIS
 .B iwevent
-zobrazí bezdrátové události pøijaté prostøednictvím socketu RTNetlink. Ka¾dı
-øádek zobrazuje jednotlivou bezdrátovou událost popisující, co se stalo
-na urèeném bezdrátovém rozhraní.
+zobrazÃ­ bezdrÃ¡tovÃ© udÃ¡losti pÅ™ijatÃ© prostÅ™ednictvÃ­m socketu RTNetlink. KaÅ¾dÃ½
+Å™Ã¡dek zobrazuje jednotlivou bezdrÃ¡tovou udÃ¡lost popisujÃ­cÃ­, co se stalo
+na urÄenÃ©m bezdrÃ¡tovÃ©m rozhranÃ­.
 .br
-Tento pøíkaz nemá ¾ádné parametry.
+Tento pÅ™Ã­kaz nemÃ¡ Å¾Ã¡dnÃ© parametry.
 .\"
 .\" DISPLAY part
 .\"
-.SH ZOBRAZENÍ
-Jsou dva typy bezdrátovıch událostí.
+.SH ZOBRAZENÃ
+Jsou dva typy bezdrÃ¡tovÃ½ch udÃ¡lostÃ­.
 .PP
-První typ jsou události vztahující se ke zmìnì bezdrátovıch nastavení na
-rozhraní (typicky prostøednictvím
+PrvnÃ­ typ jsou udÃ¡losti vztahujÃ­cÃ­ se ke zmÄ›nÄ› bezdrÃ¡tovÃ½ch nastavenÃ­ na
+rozhranÃ­ (typicky prostÅ™ednictvÃ­m
 .B iwconfig
-nebo skriptu volajícího
+nebo skriptu volajÃ­cÃ­ho
 .BR iwconfig ).
-Jsou oznamována pouze nastavení, která mohou vést k naru¹ení spojení.
-V souèasnosti jsou oznamovány události mìnící jedno z následujících
-nastavení:
+Jsou oznamovÃ¡na pouze nastavenÃ­, kterÃ¡ mohou vÃ©st k naruÅ¡enÃ­ spojenÃ­.
+V souÄasnosti jsou oznamovÃ¡ny udÃ¡losti mÄ›nÃ­cÃ­ jedno z nÃ¡sledujÃ­cÃ­ch
+nastavenÃ­:
 .br
 .I "	Network ID"
 .br
@@ -48,55 +48,55 @@ nastavení:
 .br
 .I "	Encryption"
 .br
-V¹echny tyto události jsou generovány na v¹ech bezdrátovıch rozhraních
-bezdrátovım subsystémem jádra (ale jen kdy¾ byl ovladaè pøeveden na
-nové API ovladaèù).
+VÅ¡echny tyto udÃ¡losti jsou generovÃ¡ny na vÅ¡ech bezdrÃ¡tovÃ½ch rozhranÃ­ch
+bezdrÃ¡tovÃ½m subsystÃ©mem jÃ¡dra (ale jen kdyÅ¾ byl ovladaÄ pÅ™eveden na
+novÃ© API ovladaÄÅ¯).
 .PP
-Dal¹ím typem jsou události generované hardwarem, kdy¾ se nìco stane
-nebo byl byla dokonèena úloha. Tyto události zahrnují:
+DalÅ¡Ã­m typem jsou udÃ¡losti generovanÃ© hardwarem, kdyÅ¾ se nÄ›co stane
+nebo byl byla dokonÄena Ãºloha. Tyto udÃ¡losti zahrnujÃ­:
 .TP
 .B New Access Point/Cell address
-(nová adresa pøístupového bodu/buòky) Rozhraní se pøipojilo k novému
-pøístupovému bodu èi AD-Hoc buòce nebo s ním ztratilo spojení. Je to 
-stejná MAC adresa, jako hlásí
+(novÃ¡ adresa pÅ™Ã­stupovÃ©ho bodu/buÅˆky) RozhranÃ­ se pÅ™ipojilo k novÃ©mu
+pÅ™Ã­stupovÃ©mu bodu Äi AD-Hoc buÅˆce nebo s nÃ­m ztratilo spojenÃ­. Je to 
+stejnÃ¡ MAC adresa, jako hlÃ¡sÃ­
 .BR iwconfig .
 .TP
 .B Scan request completed
-(po¾adavek na skenování dokonèen) Po¾adavek na skenování byl dokonèen,
-vısledek je k dispozici (viz
+(poÅ¾adavek na skenovÃ¡nÃ­ dokonÄen) PoÅ¾adavek na skenovÃ¡nÃ­ byl dokonÄen,
+vÃ½sledek je k dispozici (viz
 .BR iwlist 
 ).
 .TP
 .B Tx packet dropped
-(vyslanı paket zahozen) Paket smìrovanı na tuto adresu byl zahozen, proto¾e rozhraní se
-domnívá, ¾e tento node u¾ neodpovídá (obvykle pokud bylo pøekroèeno maximum
-pokusù na úrovni MAC). Toto je obvykle prvotní známka toho, ¾e
-node mohl opustit buòku nebo se ocitl mimo dosah, ale mù¾e to bıt i 
-zeslabením signálu nebo nadmìrnım ru¹ením.
+(vyslanÃ½ paket zahozen) Paket smÄ›rovanÃ½ na tuto adresu byl zahozen, protoÅ¾e rozhranÃ­ se
+domnÃ­vÃ¡, Å¾e tento node uÅ¾ neodpovÃ­dÃ¡ (obvykle pokud bylo pÅ™ekroÄeno maximum
+pokusÅ¯ na Ãºrovni MAC). Toto je obvykle prvotnÃ­ znÃ¡mka toho, Å¾e
+node mohl opustit buÅˆku nebo se ocitl mimo dosah, ale mÅ¯Å¾e to bÃ½t i 
+zeslabenÃ­m signÃ¡lu nebo nadmÄ›rnÃ½m ruÅ¡enÃ­m.
 .TP
 .B Custom driver event
-(Zvlá¹tní událost ovladaèe) Událost specifická pro ovladaè. Prosím prozkoumejte dokumentaci ovladaèe.
+(ZvlÃ¡Å¡tnÃ­ udÃ¡lost ovladaÄe) UdÃ¡lost specifickÃ¡ pro ovladaÄ. ProsÃ­m prozkoumejte dokumentaci ovladaÄe.
 .TP
 .B Registered node
-Rozhraní úspì¹nì zaregistrovalo nového bezdrátového klienta/peer.
-Vìt¹inou je generována, pokud rozhraní pracuje jako pøístupovı bod
-(re¾im master).
+RozhranÃ­ ÃºspÄ›Å¡nÄ› zaregistrovalo novÃ©ho bezdrÃ¡tovÃ©ho klienta/peer.
+VÄ›tÅ¡inou je generovÃ¡na, pokud rozhranÃ­ pracuje jako pÅ™Ã­stupovÃ½ bod
+(reÅ¾im master).
 .TP
 .B Expired node
-Registrace klienta/peer na tomto rozhraní vypr¹ela. 
-Vìt¹inou je generována, pokud rozhraní pracuje jako pøístupovı bod
-(re¾im master).
+Registrace klienta/peer na tomto rozhranÃ­ vyprÅ¡ela. 
+VÄ›tÅ¡inou je generovÃ¡na, pokud rozhranÃ­ pracuje jako pÅ™Ã­stupovÃ½ bod
+(reÅ¾im master).
 .TP
 .B Spy threshold crossed
-(pøekroèen práh pro sledování) Síla signálu u jedné z adres v seznamu iwspy poklesla pod spodní práh nebo
-pøekroèila horní práh.
+(pÅ™ekroÄen prÃ¡h pro sledovÃ¡nÃ­) SÃ­la signÃ¡lu u jednÃ© z adres v seznamu iwspy poklesla pod spodnÃ­ prÃ¡h nebo
+pÅ™ekroÄila hornÃ­ prÃ¡h.
 .PP
-Vìt¹ina bezdrátovıch ovladaèù generuje pouze èást z tìchto událostí, nikoli
-v¹echny. Jejich seznam zále¾í na konkrétní kombinaci hardware a ovladaèe.
-Pro více informací o vytváøení událostí prosím prozkoumejte dokumentaci
-ovladaèe a pou¾ijte
+VÄ›tÅ¡ina bezdrÃ¡tovÃ½ch ovladaÄÅ¯ generuje pouze ÄÃ¡st z tÄ›chto udÃ¡lostÃ­, nikoli
+vÅ¡echny. Jejich seznam zÃ¡leÅ¾Ã­ na konkrÃ©tnÃ­ kombinaci hardware a ovladaÄe.
+Pro vÃ­ce informacÃ­ o vytvÃ¡Å™enÃ­ udÃ¡lostÃ­ prosÃ­m prozkoumejte dokumentaci
+ovladaÄe a pouÅ¾ijte
 .IR iwlist (8)
-k zji¹tìní, co ovladaè podporuje.
+k zjiÅ¡tÄ›nÃ­, co ovladaÄ podporuje.
 .\"
 .\" AUTHOR part
 .\"
@@ -105,12 +105,12 @@ Jean Tourrilhes \- jt@hpl.hp.com
 .\"
 .\" TRANSLATION part
 .\"
-.SH PØEKLAD
-Pavel Heimlich \- tropikhajma@seznam.cz, bøezen 2005 (wireless_tools.28pre4).
+.SH PÅ˜EKLAD
+Pavel Heimlich \- tropikhajma@seznam.cz, bÅ™ezen 2005 (wireless_tools.28pre4).
 .\"
 .\" SEE ALSO part
 .\"
-.SH DAL©Í INFORMACE
+.SH DALÅ Ã INFORMACE
 .BR iwconfig (8),
 .BR iwlist (8),
 .BR iwspy (8),

--- a/wireless_tools/cs/iwgetid.8
+++ b/wireless_tools/cs/iwgetid.8
@@ -2,12 +2,12 @@
 .\" Doplnil a opravil Jean Tourrilhes - 2002-2003
 .\" iwgetid.8
 .\"
-.TH IWGETID 8 "2.prosinec 2003" "wireless-tools" "Linux - Manuál programátora"
+.TH IWGETID 8 "2.prosinec 2003" "wireless-tools" "Linux - ManuÃ¡l programÃ¡tora"
 .\"
 .\" NAME part
 .\"
-.SH JMÉNO
-iwgetid \- Zobrazí ESSID, NWID nebo adresu AP/Cell (pøístupového bodu/buòky) v bezdrátové síti
+.SH JMÃ‰NO
+iwgetid \- ZobrazÃ­ ESSID, NWID nebo adresu AP/Cell (pÅ™Ã­stupovÃ©ho bodu/buÅˆky) v bezdrÃ¡tovÃ© sÃ­ti
 .\"
 .\" SYNOPSIS part
 .\"
@@ -21,97 +21,97 @@ iwgetid \- Zobrazí ESSID, NWID nebo adresu AP/Cell (pøístupového bodu/buòky) v b
 .\"
 .SH POPIS
 .B iwgetid
-se pou¾ívá k zji¹tìní NWID, ESSID nebo adresy AP/Cell (pøístupového bodu/buòky)
-v bezdrátové síti, která je právì vyu¾ívána. Zobrazená informace je stejná jako
+se pouÅ¾Ã­vÃ¡ k zjiÅ¡tÄ›nÃ­ NWID, ESSID nebo adresy AP/Cell (pÅ™Ã­stupovÃ©ho bodu/buÅˆky)
+v bezdrÃ¡tovÃ© sÃ­ti, kterÃ¡ je prÃ¡vÄ› vyuÅ¾Ã­vÃ¡na. ZobrazenÃ¡ informace je stejnÃ¡ jako
 ta, kterou ukazuje
 .BR iwconfig ", ale " iwgetid
-se snadnìji integruje do skriptù.
+se snadnÄ›ji integruje do skriptÅ¯.
 .br
-Jako vıchozí,
+Jako vÃ½chozÃ­,
 .B iwgetid
-vypí¹e 
+vypÃ­Å¡e 
 .I ESSID
-zaøízení, pokud zaøízení nemá ¾ádné ESSID, vytiskne jeho
+zaÅ™Ã­zenÃ­, pokud zaÅ™Ã­zenÃ­ nemÃ¡ Å¾Ã¡dnÃ© ESSID, vytiskne jeho
 .IR NWID .
 .br
-Vıchozí formát pro vıstup je pretty-printing (èlovìkem èitelnı).
+VÃ½chozÃ­ formÃ¡t pro vÃ½stup je pretty-printing (ÄlovÄ›kem ÄitelnÃ½).
 .\"
 .\" OPTIONS part
 .\"
 .SH VOLBY
 .TP
 .B --raw
-Tento pøepínaè vypne pretty-printing.
-Je mo¾né jej kombinovat s ostatními pøepínaèi (s vıjimkou
+Tento pÅ™epÃ­naÄ vypne pretty-printing.
+Je moÅ¾nÃ© jej kombinovat s ostatnÃ­mi pÅ™epÃ­naÄi (s vÃ½jimkou
 .BR --scheme ),
-tak¾e se správnou kombinací pøepínaèù lze vytisknout surové
+takÅ¾e se sprÃ¡vnou kombinacÃ­ pÅ™epÃ­naÄÅ¯ lze vytisknout surovÃ©
 ESSID, adresu AP nebo Mode.
 .br
-Tento formát je ideální pro ulo¾ení vısledku iwgetid jako promìnné ve skriptech
+Tento formÃ¡t je ideÃ¡lnÃ­ pro uloÅ¾enÃ­ vÃ½sledku iwgetid jako promÄ›nnÃ© ve skriptech
 .I Shellu
 nebo
 .I Perlu
-nebo pro pøedání vısledku jako parametru pøíkazové øádky pro
+nebo pro pÅ™edÃ¡nÃ­ vÃ½sledku jako parametru pÅ™Ã­kazovÃ© Å™Ã¡dky pro
 .BR iwconfig .
 .TP
 .B --scheme
-Tento pøepínaè je podobnı pøedchozímu, vypne pretty-printing 
-a odstraní v¹echny znaky, které nejsou alfanumerické
-(jako mezery, interpunkci a kontrolní znaky).
+Tento pÅ™epÃ­naÄ je podobnÃ½ pÅ™edchozÃ­mu, vypne pretty-printing 
+a odstranÃ­ vÅ¡echny znaky, kterÃ© nejsou alfanumerickÃ©
+(jako mezery, interpunkci a kontrolnÃ­ znaky).
 .br
-Vıslednı vıstup je validní <<\ Pcmcia scheme identifer\ >> (kterı mù¾e bıt
-pou¾it jako parametr pøíkazu
+VÃ½slednÃ½ vÃ½stup je validnÃ­ <<\ Pcmcia scheme identifer\ >> (kterÃ½ mÅ¯Å¾e bÃ½t
+pouÅ¾it jako parametr pÅ™Ã­kazu
 .BR "cardctl scheme" ).
-Tento formát je také ideální, pokud je vısledek iwgetid pou¾it jako volba ve skriptech
+Tento formÃ¡t je takÃ© ideÃ¡lnÃ­, pokud je vÃ½sledek iwgetid pouÅ¾it jako volba ve skriptech
 .I Shellu
 nebo
 .I Perlu
-nebo jako název souboru.
+nebo jako nÃ¡zev souboru.
 .TP
 .B --ap
-Zobrazí MAC adresu bezdrátového
+ZobrazÃ­ MAC adresu bezdrÃ¡tovÃ©ho
 .I Access Point
-(pøístupového bodu) nebo
+(pÅ™Ã­stupovÃ©ho bodu) nebo
 .IR Cell .
-(buòky)
+(buÅˆky)
 .TP
 .B --freq
-Zobrazí aktuální
+ZobrazÃ­ aktuÃ¡lnÃ­
 .I frequency
 (frekvenci) nebo
 .I channel
-(kanál), pou¾ívanı rozhraním.
+(kanÃ¡l), pouÅ¾Ã­vanÃ½ rozhranÃ­m.
 .TP
 .B --channel
-Zobrazí aktuální
+ZobrazÃ­ aktuÃ¡lnÃ­
 .I channel
-(kanál), pou¾ívanı rozhraním. Kanál je získán z aktuální frekvence
-a seznamu frekvencí dodaného rozhraním.
+(kanÃ¡l), pouÅ¾Ã­vanÃ½ rozhranÃ­m. KanÃ¡l je zÃ­skÃ¡n z aktuÃ¡lnÃ­ frekvence
+a seznamu frekvencÃ­ dodanÃ©ho rozhranÃ­m.
 .TP
 .B --mode
-Zobrazí aktuální
+ZobrazÃ­ aktuÃ¡lnÃ­
 .I mode
-(re¾im) rozhraní.
+(reÅ¾im) rozhranÃ­.
 .TP
 .B --protocol
-Zobrazí
+ZobrazÃ­
 .I protocol name
-(název protokolu) rozhraní. Tak je mo¾né identifikovat v¹echny karty, které
-jsou vzájemnì kompatibilní a akceptují stejnı typ nastavení.
+(nÃ¡zev protokolu) rozhranÃ­. Tak je moÅ¾nÃ© identifikovat vÅ¡echny karty, kterÃ©
+jsou vzÃ¡jemnÄ› kompatibilnÃ­ a akceptujÃ­ stejnÃ½ typ nastavenÃ­.
 .br
-Je to také mo¾nost jak 
-.I ovìøit podporu Wireless Extensions
-na rozhraní, proto¾e je to jedinı atribut,
-kterı v¹echny ovladaèe podporující Wireless Extensions musejí podporovat.
+Je to takÃ© moÅ¾nost jak 
+.I ovÄ›Å™it podporu Wireless Extensions
+na rozhranÃ­, protoÅ¾e je to jedinÃ½ atribut,
+kterÃ½ vÅ¡echny ovladaÄe podporujÃ­cÃ­ Wireless Extensions musejÃ­ podporovat.
 .\"
 .\" TRANSLATION part
 .\"
-.SH PØEKLAD
-Pavel Heimlich \- tropikhajma@seznam.cz, bøezen 2005 (wireless_tools.28pre4).
+.SH PÅ˜EKLAD
+Pavel Heimlich \- tropikhajma@seznam.cz, bÅ™ezen 2005 (wireless_tools.28pre4).
 .\"
 .\" SEE ALSO part
 .\"
-.SH DAL©Í INFORMACE
+.SH DALÅ Ã INFORMACE
 .BR iwconfig (8),
 .BR ifconfig (8),
 .BR iwspy (8),

--- a/wireless_tools/cs/iwlist.8
+++ b/wireless_tools/cs/iwlist.8
@@ -1,31 +1,31 @@
 .\" Jean II - HPLB - 96
 .\" iwlist.8
 .\"
-.TH IWLIST 8 "23.èerven 2004" "wireless-tools" "Linux - Manuál programátora"
+.TH IWLIST 8 "23.Äerven 2004" "wireless-tools" "Linux - ManuÃ¡l programÃ¡tora"
 .\"
 .\" NAME part
 .\"
-.SH JMÉNO
-iwlist \- Získá podrobnìj¹í bezdrátové informace o bezdrátovém rozhraní
+.SH JMÃ‰NO
+iwlist \- ZÃ­skÃ¡ podrobnÄ›jÅ¡Ã­ bezdrÃ¡tovÃ© informace o bezdrÃ¡tovÃ©m rozhranÃ­
 .\"
 .\" SYNOPSIS part
 .\"
 .SH SYNTAXE
-.BI "iwlist " rozhraní " scanning"
+.BI "iwlist " rozhranÃ­ " scanning"
 .br
-.BI "iwlist " rozhraní " frequency"
+.BI "iwlist " rozhranÃ­ " frequency"
 .br
-.BI "iwlist " rozhraní " rate"
+.BI "iwlist " rozhranÃ­ " rate"
 .br
-.BI "iwlist " rozhraní " key"
+.BI "iwlist " rozhranÃ­ " key"
 .br
-.BI "iwlist " rozhraní " power"
+.BI "iwlist " rozhranÃ­ " power"
 .br
-.BI "iwlist " rozhraní " txpower"
+.BI "iwlist " rozhranÃ­ " txpower"
 .br
-.BI "iwlist " rozhraní " retry"
+.BI "iwlist " rozhranÃ­ " retry"
 .br
-.BI "iwlist " rozhraní " event"
+.BI "iwlist " rozhranÃ­ " event"
 .br
 .BI "iwlist --help"
 .br
@@ -35,12 +35,12 @@ iwlist \- Získá podrobnìj¹í bezdrátové informace o bezdrátovém rozhraní
 .\"
 .SH POPIS
 .B Iwlist
-se pou¾ívá k zobrazení doplòujících informací o bezdrátovém sí»ovém
-rozhraní, které nejsou zobrazovány pøíkazem
+se pouÅ¾Ã­vÃ¡ k zobrazenÃ­ doplÅˆujÃ­cÃ­ch informacÃ­ o bezdrÃ¡tovÃ©m sÃ­Å¥ovÃ©m
+rozhranÃ­, kterÃ© nejsou zobrazovÃ¡ny pÅ™Ã­kazem
 .IR iwconfig (8).
-Hlavní parametr urèuje typ informace, kterou
+HlavnÃ­ parametr urÄuje typ informace, kterou
 .B iwlist
-zobrazí v detailní podobì, vèetnì informace, kterou poskytuje
+zobrazÃ­ v detailnÃ­ podobÄ›, vÄetnÄ› informace, kterou poskytuje
 .IR iwconfig (8).
 .\"
 .\" PARAMETER part
@@ -48,61 +48,61 @@ zobrazí v detailní podobì, vèetnì informace, kterou poskytuje
 .SH PARAMETRY
 .TP
 .BR scan [ning]
-Vypí¹e seznam pøístupovıch bodù a Ad-Hoc buòek v dosahu a 
-volitelnì i spoustu informací o nich (ESSID, kvalita,
-frekvence, re¾im...). Typ zobrazené informace závisí na mo¾nostech karty.
+VypÃ­Å¡e seznam pÅ™Ã­stupovÃ½ch bodÅ¯ a Ad-Hoc buÅˆek v dosahu a 
+volitelnÄ› i spoustu informacÃ­ o nich (ESSID, kvalita,
+frekvence, reÅ¾im...). Typ zobrazenÃ© informace zÃ¡visÃ­ na moÅ¾nostech karty.
 .br
-Spu¹tìní skenování je privilegovaná operace (mù¾e ji provést pouze
+SpuÅ¡tÄ›nÃ­ skenovÃ¡nÃ­ je privilegovanÃ¡ operace (mÅ¯Å¾e ji provÃ©st pouze
 .RI root
-) a normální u¾ivatel mù¾e pouze èíst zbylé vısledky skenování. 
-Jako vıchozí je zpùsob, kterım je skenování provedeno (jeho rozsah)
-ovlivnìn aktuálním nastavením ovladaèe. U tohoto pøíkazu se poèítá s dodateènımi parametry
-pro kontrolu zpùsobu skenování, to ale zatím není implementováno.
+) a normÃ¡lnÃ­ uÅ¾ivatel mÅ¯Å¾e pouze ÄÃ­st zbylÃ© vÃ½sledky skenovÃ¡nÃ­. 
+Jako vÃ½chozÃ­ je zpÅ¯sob, kterÃ½m je skenovÃ¡nÃ­ provedeno (jeho rozsah)
+ovlivnÄ›n aktuÃ¡lnÃ­m nastavenÃ­m ovladaÄe. U tohoto pÅ™Ã­kazu se poÄÃ­tÃ¡ s dodateÄnÃ½mi parametry
+pro kontrolu zpÅ¯sobu skenovÃ¡nÃ­, to ale zatÃ­m nenÃ­ implementovÃ¡no.
 .TP
 .BR freq [uency]/ channel
-Vypí¹e seznam dostupnıch frekvencí pro zaøízení a poèet definovanıch kanálù
-Prosím vìnujte pozornost tomu, ¾e ovladaè obvykle vrací
-celkovı poèet kanálù a pouze frekvence dostupné v aktuálním locale,
-tak¾e mezi zobrazenımi frekvencemi a èísly kanálù není vztah "jedna k jedné".
+VypÃ­Å¡e seznam dostupnÃ½ch frekvencÃ­ pro zaÅ™Ã­zenÃ­ a poÄet definovanÃ½ch kanÃ¡lÅ¯
+ProsÃ­m vÄ›nujte pozornost tomu, Å¾e ovladaÄ obvykle vracÃ­
+celkovÃ½ poÄet kanÃ¡lÅ¯ a pouze frekvence dostupnÃ© v aktuÃ¡lnÃ­m locale,
+takÅ¾e mezi zobrazenÃ½mi frekvencemi a ÄÃ­sly kanÃ¡lÅ¯ nenÃ­ vztah "jedna k jednÃ©".
 .TP
 .BR rate / bit [rate]
-Vypí¹e pøenosové rychlosti podporované zaøízením.
+VypÃ­Å¡e pÅ™enosovÃ© rychlosti podporovanÃ© zaÅ™Ã­zenÃ­m.
 .TP
 .BR key / enc [ryption]
-Vypí¹e podporované velikosti ¹ifrovacích klíèù a zobrazí v¹echny ¹ifrovací
-klíèe dostupné v zaøízení.
+VypÃ­Å¡e podporovanÃ© velikosti Å¡ifrovacÃ­ch klÃ­ÄÅ¯ a zobrazÃ­ vÅ¡echny Å¡ifrovacÃ­
+klÃ­Äe dostupnÃ© v zaÅ™Ã­zenÃ­.
 .TP
 .B power
-Vypí¹e rùzné atributy a re¾imy øízení spotøeby zaøízení.
+VypÃ­Å¡e rÅ¯znÃ© atributy a reÅ¾imy Å™Ã­zenÃ­ spotÅ™eby zaÅ™Ã­zenÃ­.
 .TP
 .B txpower
-vypí¹e dostupné vysílací vıkony zaøízení.
+vypÃ­Å¡e dostupnÃ© vysÃ­lacÃ­ vÃ½kony zaÅ™Ã­zenÃ­.
 .TP
 .B retry
-vypí¹e limity pro transmit retry a retry lifetime na zaøízení.
+vypÃ­Å¡e limity pro transmit retry a retry lifetime na zaÅ™Ã­zenÃ­.
 .TP
 .BR ap / accesspoint / peers
-Vypí¹e pøístupové body v dosahu a volitelnì i kvalitu spoje
+VypÃ­Å¡e pÅ™Ã­stupovÃ© body v dosahu a volitelnÄ› i kvalitu spoje
 Tato volba je 
-.B zastaralá
-a je nyní opu¹tìna ve prospìch skenování (viz vı¹e), vìt¹ina
-ovladaèù ji nepodporuje.
+.B zastaralÃ¡
+a je nynÃ­ opuÅ¡tÄ›na ve prospÄ›ch skenovÃ¡nÃ­ (viz vÃ½Å¡e), vÄ›tÅ¡ina
+ovladaÄÅ¯ ji nepodporuje.
 .br
-Nìkteré ovladaèe mohou s tímto pøíkazem vracet zvlá¹tní seznam peerù
-nebo pøístupovıch bodù, jako napø. seznam peerù asociovaních s/registrovanıch s
-kartou. Více informací obsahuje dokumentace ovladaèù.
+NÄ›kterÃ© ovladaÄe mohou s tÃ­mto pÅ™Ã­kazem vracet zvlÃ¡Å¡tnÃ­ seznam peerÅ¯
+nebo pÅ™Ã­stupovÃ½ch bodÅ¯, jako napÅ™. seznam peerÅ¯ asociovanÃ­ch s/registrovanÃ½ch s
+kartou. VÃ­ce informacÃ­ obsahuje dokumentace ovladaÄÅ¯.
 .TP
 .B event
-Vypí¹e bezdrátové události podporované zaøízením.
+VypÃ­Å¡e bezdrÃ¡tovÃ© udÃ¡losti podporovanÃ© zaÅ™Ã­zenÃ­m.
 .TP
 .B --version
-Zobrazí verzi wireless tools a doporuèenou a aktuální verzi Wireless Extensions
-s ohledem na bezdrátové rozhraní.
+ZobrazÃ­ verzi wireless tools a doporuÄenou a aktuÃ¡lnÃ­ verzi Wireless Extensions
+s ohledem na bezdrÃ¡tovÃ© rozhranÃ­.
 .\"
 .\" TRANSLATION part
 .\"
-.SH PØEKLAD
-Pavel Heimlich \- tropikhajma@seznam.cz, bøezen 2005 (wireless_tools.28pre4).
+.SH PÅ˜EKLAD
+Pavel Heimlich \- tropikhajma@seznam.cz, bÅ™ezen 2005 (wireless_tools.28pre4).
 .\"
 .\" FILES part
 .\"
@@ -111,7 +111,7 @@ Pavel Heimlich \- tropikhajma@seznam.cz, bøezen 2005 (wireless_tools.28pre4).
 .\"
 .\" SEE ALSO part
 .\"
-.SH DAL©Í INFORMACE
+.SH DALÅ Ã INFORMACE
 .BR iwconfig (8),
 .BR iwspy (8).
 .BR iwevent (8),

--- a/wireless_tools/cs/iwpriv.8
+++ b/wireless_tools/cs/iwpriv.8
@@ -1,102 +1,102 @@
 .\" Jean II - HPLB - 96
 .\" iwpriv.8
 .\"
-.TH IWPRIV 8 "31.øíjen 1996" "net-tools" "Linux - Manuál programátora"
+.TH IWPRIV 8 "31.Å™Ã­jen 1996" "net-tools" "Linux - ManuÃ¡l programÃ¡tora"
 .\"
 .\" NAME part
 .\"
-.SH JMÉNO
-iwpriv \- konfiguruje doplòkové (specifické) parametry bezdrátového
-sí»ového rozhraní
+.SH JMÃ‰NO
+iwpriv \- konfiguruje doplÅˆkovÃ© (specifickÃ©) parametry bezdrÃ¡tovÃ©ho
+sÃ­Å¥ovÃ©ho rozhranÃ­
 .\"
 .\" SYNOPSIS part
 .\"
 .SH SYNTAXE
-.BI "iwpriv [" rozhraní ]
+.BI "iwpriv [" rozhranÃ­ ]
 .br
-.BI "iwpriv " "rozhraní specifickı-pøíkaz " "[" specifické-parametry ]
+.BI "iwpriv " "rozhranÃ­ specifickÃ½-pÅ™Ã­kaz " "[" specifickÃ©-parametry ]
 .br
-.BI "iwpriv " "rozhraní specifickı-pøíkaz [I] " "[" specifické-parametry ]
+.BI "iwpriv " "rozhranÃ­ specifickÃ½-pÅ™Ã­kaz [I] " "[" specifickÃ©-parametry ]
 .br
-.BI "iwpriv " rozhraní " --all"
+.BI "iwpriv " rozhranÃ­ " --all"
 .br
-.BI "iwpriv " rozhraní " roam " {on,off}
+.BI "iwpriv " rozhranÃ­ " roam " {on,off}
 .br
-.BI "iwpriv " rozhraní " port " {ad-hoc,managed,N}
+.BI "iwpriv " rozhranÃ­ " port " {ad-hoc,managed,N}
 .\"
 .\" DESCRIPTION part
 .\"
 .SH POPIS
 .B Iwpriv
-je doprovodnım nástrojem k
+je doprovodnÃ½m nÃ¡strojem k
 .IR iwconfig (8).
 .B Iwpriv
-pracuje s parametry a nastaveními specifickımi pro ka¾dı ovladaè (na rozdíl od
+pracuje s parametry a nastavenÃ­mi specifickÃ½mi pro kaÅ¾dÃ½ ovladaÄ (na rozdÃ­l od
 .IR "iwconfig" ,
-kterı pracuje s obecnımi).
+kterÃ½ pracuje s obecnÃ½mi).
 .PP
-Bez uvedení parametru
+Bez uvedenÃ­ parametru
 .B iwpriv
-vypí¹e specifické pøikazy dostupné na ka¾dém rozhraní a 
-parametry, které vy¾adují. Pomocí této informace mù¾e u¾ivatel
-pou¾ít tyto specifické pøíkazy na urèeném rozhraní.
+vypÃ­Å¡e specifickÃ© pÅ™ikazy dostupnÃ© na kaÅ¾dÃ©m rozhranÃ­ a 
+parametry, kterÃ© vyÅ¾adujÃ­. PomocÃ­ tÃ©to informace mÅ¯Å¾e uÅ¾ivatel
+pouÅ¾Ã­t tyto specifickÃ© pÅ™Ã­kazy na urÄenÃ©m rozhranÃ­.
 .PP
-Teoreticky by dokumentace ka¾dého ovladaèe mìla uvádìt, jak
-pou¾ívat tyto pro rozhraní specifické pøíkazy a jejich úèinek.
+Teoreticky by dokumentace kaÅ¾dÃ©ho ovladaÄe mÄ›la uvÃ¡dÄ›t, jak
+pouÅ¾Ã­vat tyto pro rozhranÃ­ specifickÃ© pÅ™Ã­kazy a jejich ÃºÄinek.
 .\"
 .\" PARAMETER part
 .\"
 .SH PARAMETRY
 .TP
-.IR specifickı-pøíkaz " [" specifické-parametry ]
-Vykoná urèenı
-.I specifickı-pøíkaz
-na rozhraní.
+.IR specifickÃ½-pÅ™Ã­kaz " [" specifickÃ©-parametry ]
+VykonÃ¡ urÄenÃ½
+.I specifickÃ½-pÅ™Ã­kaz
+na rozhranÃ­.
 .br
-Pøíkaz mù¾e pou¾ít nebo vy¾adovat parametry a mù¾e zobrazit informaci.
-Parametry tedy mohou i nemusejí bıt vy¾adovány a mìly by odpovídat tomu, co
-pøíkaz oèekává. Seznam pøíkazù, které
+PÅ™Ã­kaz mÅ¯Å¾e pouÅ¾Ã­t nebo vyÅ¾adovat parametry a mÅ¯Å¾e zobrazit informaci.
+Parametry tedy mohou i nemusejÃ­ bÃ½t vyÅ¾adovÃ¡ny a mÄ›ly by odpovÃ­dat tomu, co
+pÅ™Ã­kaz oÄekÃ¡vÃ¡. Seznam pÅ™Ã­kazÅ¯, kterÃ©
 .B iwpriv
-zobrazí (kdy¾ je volán bez parametrù), by mìl napovìdìt, jak s parametry zacházet.
+zobrazÃ­ (kdyÅ¾ je volÃ¡n bez parametrÅ¯), by mÄ›l napovÄ›dÄ›t, jak s parametry zachÃ¡zet.
 .br
-Nicménì pro informaci o pøíkazech a jejich správném pou¾ití je nejlep¹í
-se obrátit na dokumnetaci k ovladaèi zaøízení.
+NicmÃ©nÄ› pro informaci o pÅ™Ã­kazech a jejich sprÃ¡vnÃ©m pouÅ¾itÃ­ je nejlepÅ¡Ã­
+se obrÃ¡tit na dokumnetaci k ovladaÄi zaÅ™Ã­zenÃ­.
 .TP
-.I "specifickı-pøíkaz [I]" "[" specifické-parametry ]
-Viz vı¹e, pouze
+.I "specifickÃ½-pÅ™Ã­kaz [I]" "[" specifickÃ©-parametry ]
+Viz vÃ½Å¡e, pouze
 .I I
-(celé èíslo) je pøedáno pøíkazu jako
+(celÃ© ÄÃ­slo) je pÅ™edÃ¡no pÅ™Ã­kazu jako
 .IR "Token Index" .
-Token Index pou¾ívají jen nìkteré pøíkazy (vìt¹ina jej ignoruje), kdy jej pou¾ít by
-mìla øíci dokumnetace ovladaèe.
+Token Index pouÅ¾Ã­vajÃ­ jen nÄ›kterÃ© pÅ™Ã­kazy (vÄ›tÅ¡ina jej ignoruje), kdy jej pouÅ¾Ã­t by
+mÄ›la Å™Ã­ci dokumnetace ovladaÄe.
 .TP
 .BR -a / --all
-Vykoná a zobrazí v¹echny specifické pøíkazy, které nemají ¾ádné parametry
-(tj. pouze ètou).
+VykonÃ¡ a zobrazÃ­ vÅ¡echny specifickÃ© pÅ™Ã­kazy, kterÃ© nemajÃ­ Å¾Ã¡dnÃ© parametry
+(tj. pouze Ätou).
 .TP
 .B roam
-Povolí nebo zaká¾e roaming, je-li podporován. Volá specifickı pøíkaz
+PovolÃ­ nebo zakÃ¡Å¾e roaming, je-li podporovÃ¡n. VolÃ¡ specifickÃ½ pÅ™Ã­kaz
 .IR setroam ,
-kterı je obsa¾en v ovladaèi
+kterÃ½ je obsaÅ¾en v ovladaÄi
 .IR "wavelan_cs".
 .TP
 .B port
-Pøeète nebo nastaví druh portu. Volá specifickı pøíkaz
+PÅ™eÄte nebo nastavÃ­ druh portu. VolÃ¡ specifickÃ½ pÅ™Ã­kaz
 .IR gport_type ", " sport_type ", " get_port " nebo " set_port ","
-obsa¾enı v ovladaèích
+obsaÅ¾enÃ½ v ovladaÄÃ­ch
 .IR wavelan2_cs " a " wvlan_cs "."
 .\"
 .\" DISPLAY part
 .\"
-.SH ZOBRAZENÍ
-Pro ka¾dé zaøízení, které podporuje specifické pøíkazy, zobrazí
+.SH ZOBRAZENÃ
+Pro kaÅ¾dÃ© zaÅ™Ã­zenÃ­, kterÃ© podporuje specifickÃ© pÅ™Ã­kazy, zobrazÃ­
 .I iwpriv
-seznam dostupnıch specifickıch pøíkazù.
+seznam dostupnÃ½ch specifickÃ½ch pÅ™Ã­kazÅ¯.
 .PP
-To zahrnuje název specifického pøíkazu, parametry, které mohou bıt nastaveny a jejich typ
-a parametry které mohou bıt zobrazeny a jejich typ.
+To zahrnuje nÃ¡zev specifickÃ©ho pÅ™Ã­kazu, parametry, kterÃ© mohou bÃ½t nastaveny a jejich typ
+a parametry kterÃ© mohou bÃ½t zobrazeny a jejich typ.
 .PP
-Napøíklad mù¾e zobrazit :
+NapÅ™Ã­klad mÅ¯Å¾e zobrazit :
 .br
 .B "eth0      Available specific ioctl :"
 .br
@@ -104,8 +104,8 @@ Napøíklad mù¾e zobrazit :
 .br
 .B "          gethisto (89F7) : set   0      & get  16 int"
 .PP
-To znamená, ¾e je mo¾né nastavit quality threshold a zobrazit
-histogram s a¾ 16 hodnotami pomocí tìchto pøíkazù:
+To znamenÃ¡, Å¾e je moÅ¾nÃ© nastavit quality threshold a zobrazit
+histogram s aÅ¾ 16 hodnotami pomocÃ­ tÄ›chto pÅ™Ã­kazÅ¯:
 .br
 .I "  iwpriv eth0 setqualthr 20"
 .br
@@ -118,8 +118,8 @@ Jean Tourrilhes \- jt@hpl.hp.com
 .\"
 .\" TRANSLATION part
 .\"
-.SH PØEKLAD
-Pavel Heimlich \- tropikhajma@seznam.cz, bøezen 2005 (wireless_tools.28pre4).
+.SH PÅ˜EKLAD
+Pavel Heimlich \- tropikhajma@seznam.cz, bÅ™ezen 2005 (wireless_tools.28pre4).
 .\"
 .\" FILES part
 .\"
@@ -128,7 +128,7 @@ Pavel Heimlich \- tropikhajma@seznam.cz, bøezen 2005 (wireless_tools.28pre4).
 .\"
 .\" SEE ALSO part
 .\"
-.SH DAL©Í INFORMACE
+.SH DALÅ Ã INFORMACE
 .BR iwconfig (8),
 .BR iwlist (8),
 .BR iwevent (8),

--- a/wireless_tools/cs/iwspy.8
+++ b/wireless_tools/cs/iwspy.8
@@ -1,99 +1,99 @@
 .\" Jean II - HPLB - 96
 .\" iwspy.8
 .\"
-.TH IWSPY 8 "31.øíjen 1996" "net-tools" "Linux - Manuál programátora"
+.TH IWSPY 8 "31.Å™Ã­jen 1996" "net-tools" "Linux - ManuÃ¡l programÃ¡tora"
 .\"
 .\" NAME part
 .\"
-.SH JMÉNO
-iwspy \- Získá bezdrátové statistiky o urèenıch nodech
+.SH JMÃ‰NO
+iwspy \- ZÃ­skÃ¡ bezdrÃ¡tovÃ© statistiky o urÄenÃ½ch nodech
 .\"
 .\" SYNOPSIS part
 .\"
 .SH SYNTYXE
-.BI "iwspy " rozhraní 
+.BI "iwspy " rozhranÃ­ 
 .br
-.BI "iwspy " rozhraní " [+] " DNSNAME " | " IPADDR " | " HWADDR " [...]"
+.BI "iwspy " rozhranÃ­ " [+] " DNSNAME " | " IPADDR " | " HWADDR " [...]"
 .br
-.BI "iwspy " rozhraní " off"
+.BI "iwspy " rozhranÃ­ " off"
 .br
-.BI "iwspy " rozhraní " setthr " "low high"
+.BI "iwspy " rozhranÃ­ " setthr " "low high"
 .br
-.BI "iwspy " rozhraní " getthr"
+.BI "iwspy " rozhranÃ­ " getthr"
 .\"
 .\" DESCRIPTION part
 .\"
 .SH POPIS
 .B Iwspy
-se pou¾ívá k nastavení seznamu sledovanıch adres na bezdrátovém sí»ovém rozhraní a
-k zpìtnému ètení informací o kvalitì spoje pro ka¾dou z nich. Tyto
-informace jsou stejné jako ty uvedené v
+se pouÅ¾Ã­vÃ¡ k nastavenÃ­ seznamu sledovanÃ½ch adres na bezdrÃ¡tovÃ©m sÃ­Å¥ovÃ©m rozhranÃ­ a
+k zpÄ›tnÃ©mu ÄtenÃ­ informacÃ­ o kvalitÄ› spoje pro kaÅ¾dou z nich. Tyto
+informace jsou stejnÃ© jako ty uvedenÃ© v
 .IR "/proc/net/wireless":
-kvalita spoje, síla signálu, hladina ¹umu.
+kvalita spoje, sÃ­la signÃ¡lu, hladina Å¡umu.
 .PP
-Tyto informace jsou aktualizovány poka¾dé, kdy¾ je pøijat novı paket, tak¾e
-ka¾dá adresa na seznamu zvy¹uje zátì¾ ovladaèe.
+Tyto informace jsou aktualizovÃ¡ny pokaÅ¾dÃ©, kdyÅ¾ je pÅ™ijat novÃ½ paket, takÅ¾e
+kaÅ¾dÃ¡ adresa na seznamu zvyÅ¡uje zÃ¡tÄ›Å¾ ovladaÄe.
 .PP
-Tato funkcionalita platí pouze pro nody v aktuální bezdrátové buòce, není mo¾né 
-sledovat pøístupové body, se kterımi není zaøízení asociováno (k tomu slou¾í skenování)
-, ani nody v jinıch buòkách. V re¾imu Managed procházejí pakety vìt¹inou pøes pøístupovı
-bod a v tom pøípadì je získána síla signálu pøístupového bodu. Proto je tato funkce 
-u¾iteèná víceménì jen v re¾imu Ad-Hoc nebo Master.
+Tato funkcionalita platÃ­ pouze pro nody v aktuÃ¡lnÃ­ bezdrÃ¡tovÃ© buÅˆce, nenÃ­ moÅ¾nÃ© 
+sledovat pÅ™Ã­stupovÃ© body, se kterÃ½mi nenÃ­ zaÅ™Ã­zenÃ­ asociovÃ¡no (k tomu slouÅ¾Ã­ skenovÃ¡nÃ­)
+, ani nody v jinÃ½ch buÅˆkÃ¡ch. V reÅ¾imu Managed prochÃ¡zejÃ­ pakety vÄ›tÅ¡inou pÅ™es pÅ™Ã­stupovÃ½
+bod a v tom pÅ™Ã­padÄ› je zÃ­skÃ¡na sÃ­la signÃ¡lu pÅ™Ã­stupovÃ©ho bodu. Proto je tato funkce 
+uÅ¾iteÄnÃ¡ vÃ­cemÃ©nÄ› jen v reÅ¾imu Ad-Hoc nebo Master.
 .\"
 .\" PARAMETER part
 .\"
 .SH PARAMETRY
-Je mo¾né nastavit a¾ 8 adres.
+Je moÅ¾nÃ© nastavit aÅ¾ 8 adres.
 .TP
 .BR DNSNAME " | " IPADDR
-Nastaví IP adresu nebo, v nìkterıch pøípadech, DNS název (pomocí name
-resolveru). Proto¾e hardware pracuje s hardwarovımi adresami,
+NastavÃ­ IP adresu nebo, v nÄ›kterÃ½ch pÅ™Ã­padech, DNS nÃ¡zev (pomocÃ­ name
+resolveru). ProtoÅ¾e hardware pracuje s hardwarovÃ½mi adresami,
 .B iwspy
-pøelo¾í IP adresu pomocí
+pÅ™eloÅ¾Ã­ IP adresu pomocÃ­
 .IR ARP .
-Mù¾e se stát, ¾e adresa není v ARP cache a
+MÅ¯Å¾e se stÃ¡t, Å¾e adresa nenÃ­ v ARP cache a
 .B iwspy
-neuspìje. V tom pøípadì pou¾ijte
+neuspÄ›je. V tom pÅ™Ã­padÄ› pouÅ¾ijte
 .IR ping (8)
-na toto jméno/adresu a zkuste to znovu.
+na toto jmÃ©no/adresu a zkuste to znovu.
 .TP
 .B HWADDR
-Nastaví hardwarovou (MAC) adresu (tato adresa se nepøekládá ani nekontroluje,
-na rozdíl od IP adresy). Adresa musí obsahuvat dvojteèky
+NastavÃ­ hardwarovou (MAC) adresu (tato adresa se nepÅ™eklÃ¡dÃ¡ ani nekontroluje,
+na rozdÃ­l od IP adresy). Adresa musÃ­ obsahuvat dvojteÄky
 .RB ( : )
-aby byla uznána za hardwarovou adresu.
+aby byla uznÃ¡na za hardwarovou adresu.
 .TP
 .B +
-Pøidá novou sadu adres na konec stávajícího seznamu, místo aby jej nahradil.
-Seznam adres je pro ka¾dé zaøízení jedineènı, proto by tato volba mìla bıt u¾ívána, aby
-se zabránilo konfliktùm.
+PÅ™idÃ¡ novou sadu adres na konec stÃ¡vajÃ­cÃ­ho seznamu, mÃ­sto aby jej nahradil.
+Seznam adres je pro kaÅ¾dÃ© zaÅ™Ã­zenÃ­ jedineÄnÃ½, proto by tato volba mÄ›la bÃ½t uÅ¾Ã­vÃ¡na, aby
+se zabrÃ¡nilo konfliktÅ¯m.
 .TP
 .B off
-Odstraní souèasnı seznam adres a vypne sledovací funkci.
+OdstranÃ­ souÄasnÃ½ seznam adres a vypne sledovacÃ­ funkci.
 .TP
 .B setthr
-Nastaví
+NastavÃ­
 .I low
-(spodní) a
+(spodnÃ­) a
 .I high
-(horní) práh síly signálu, pro spu¹tìní události iwspy (podporuje-li to ovladaè).
+(hornÃ­) prÃ¡h sÃ­ly signÃ¡lu, pro spuÅ¡tÄ›nÃ­ udÃ¡losti iwspy (podporuje-li to ovladaÄ).
 .br
-Poka¾dé, kdy¾ síla signálu jakékoliv z adres sledované iwspy
-poklesne pod spodní práh nebo pøehroèí horní práh, je vygenerována bezdrátová událost.
+PokaÅ¾dÃ©, kdyÅ¾ sÃ­la signÃ¡lu jakÃ©koliv z adres sledovanÃ© iwspy
+poklesne pod spodnÃ­ prÃ¡h nebo pÅ™ehroÄÃ­ hornÃ­ prÃ¡h, je vygenerovÃ¡na bezdrÃ¡tovÃ¡ udÃ¡lost.
 .br
-To je mo¾né pou¾ít ke sledování vıpadkù spoje bez nutnosti pravidelného spou¹tìní iwspy.
+To je moÅ¾nÃ© pouÅ¾Ã­t ke sledovÃ¡nÃ­ vÃ½padkÅ¯ spoje bez nutnosti pravidelnÃ©ho spouÅ¡tÄ›nÃ­ iwspy.
 .TP
 .B getthr
-Získá aktuální
+ZÃ­skÃ¡ aktuÃ¡lnÃ­
 .I low
-(spodní) a 
+(spodnÃ­) a 
 .I high
-(horní) práh síly signálu pro událost iwspy.
+(hornÃ­) prÃ¡h sÃ­ly signÃ¡lu pro udÃ¡lost iwspy.
 .\"
 .\" TRANSLATION part
 .\"
-.SH PØEKLAD
-Pavel Heimlich \- tropikhajma@seznam.cz, bøezen 2005 (wireless_tools.28pre4).
+.SH PÅ˜EKLAD
+Pavel Heimlich \- tropikhajma@seznam.cz, bÅ™ezen 2005 (wireless_tools.28pre4).
 \"
 .\" FILES part
 .\"
@@ -102,7 +102,7 @@ Pavel Heimlich \- tropikhajma@seznam.cz, bøezen 2005 (wireless_tools.28pre4).
 .\"
 .\" SEE ALSO part
 .\"
-.SH DAL©Í INFORMACE
+.SH DALÅ Ã INFORMACE
 .BR iwconfig (8),
 .BR iwlist (8),
 .BR iwevent (8),

--- a/wireless_tools/cs/wireless.7
+++ b/wireless_tools/cs/wireless.7
@@ -1,11 +1,11 @@
 .\" Jean Tourrilhes - HPL - 2002 - 2004
 .\" wireless.7
 .\"
-.TH WIRELESS 7 "4.duben 2004" "wireless-tools" "Linux - Manuál programátora"
+.TH WIRELESS 7 "4.duben 2004" "wireless-tools" "Linux - ManuÃ¡l programÃ¡tora"
 .\"
 .\" NAME part
 .\"
-.SH JMÉNO
+.SH JMÃ‰NO
 wireless \- Wireless Tools a Wireless Extensions
 .\"
 .\" SYNOPSIS part
@@ -20,25 +20,25 @@ wireless \- Wireless Tools a Wireless Extensions
 .\"
 .SH POPIS
 .B Wireless Extensions
-jsou API, které umo¾òují manipulovat s bezdrátovımi sí»ovımi rozhraními.
-Skládají se ze souboru nástrojù a konfiguraèních souborù. Podrobnìji
-jsou popsány v Linux Wireless LAN Howto.
+jsou API, kterÃ© umoÅ¾ÅˆujÃ­ manipulovat s bezdrÃ¡tovÃ½mi sÃ­Å¥ovÃ½mi rozhranÃ­mi.
+SklÃ¡dajÃ­ se ze souboru nÃ¡strojÅ¯ a konfiguraÄnÃ­ch souborÅ¯. PodrobnÄ›ji
+jsou popsÃ¡ny v Linux Wireless LAN Howto.
 .br
 .B Wireless Tools
-se pou¾ívají ke zmìnì konfigurace bezdrátovıch sí»ovıch rozhraní za bìhu,
-k získání jejich aktuální konfigurace, statistik a diagnostice.
-Popisují je jejich vlastní manuálové stránky, viz odkazy ní¾e.
+se pouÅ¾Ã­vajÃ­ ke zmÄ›nÄ› konfigurace bezdrÃ¡tovÃ½ch sÃ­Å¥ovÃ½ch rozhranÃ­ za bÄ›hu,
+k zÃ­skÃ¡nÃ­ jejich aktuÃ¡lnÃ­ konfigurace, statistik a diagnostice.
+PopisujÃ­ je jejich vlastnÃ­ manuÃ¡lovÃ© strÃ¡nky, viz odkazy nÃ­Å¾e.
 .br
-.B Nastavení bezdrátového pøipojení
-se v ka¾dé distribuci linuxu li¹í. Tato manuálová stránka bude obsahovat
-postup nastavení pro nìkolik bì¾nıch distribucí. Prozatím se podívejte do 
-souboru DISTRIBUTIONS.txt, kterı je souèástí balíèku Wireless Tools.
+.B NastavenÃ­ bezdrÃ¡tovÃ©ho pÅ™ipojenÃ­
+se v kaÅ¾dÃ© distribuci linuxu liÅ¡Ã­. Tato manuÃ¡lovÃ¡ strÃ¡nka bude obsahovat
+postup nastavenÃ­ pro nÄ›kolik bÄ›Å¾nÃ½ch distribucÃ­. ProzatÃ­m se podÃ­vejte do 
+souboru DISTRIBUTIONS.txt, kterÃ½ je souÄÃ¡stÃ­ balÃ­Äku Wireless Tools.
 .\"
 .\" DEBIAN 3.0 part
 .\"
 .SH DEBIAN 3.0
-V Debianu 3.0 (a vy¹¹ím) je mo¾né nastavit bezdrátová sí»ová zaøízení
-nástrojem pro nastavení sítì
+V Debianu 3.0 (a vyÅ¡Å¡Ã­m) je moÅ¾nÃ© nastavit bezdrÃ¡tovÃ¡ sÃ­Å¥ovÃ¡ zaÅ™Ã­zenÃ­
+nÃ¡strojem pro nastavenÃ­ sÃ­tÄ›
 .BR ifupdown (8).
 .TP
 .B Soubor:
@@ -51,7 +51,7 @@ wireless\-essid Home
 .br
 wireless\-mode Ad\-Hoc
 .TP
-.B Dal¹í informace:
+.B DalÅ¡Ã­ informace:
 .I /etc/network/if\-pre\-up.d/wireless\-tools
 .br
 .I /usr/share/doc/wireless\-tools/README.Debian
@@ -59,10 +59,10 @@ wireless\-mode Ad\-Hoc
 .\" SuSE 8.0 part
 .\"
 .SH SuSE 8.0
-SuSE 8.0 (a vy¹¹í) integrovalo nastavení bezdrátového pøipojení do svıch
-sí»ovıch skriptù.
+SuSE 8.0 (a vyÅ¡Å¡Ã­) integrovalo nastavenÃ­ bezdrÃ¡tovÃ©ho pÅ™ipojenÃ­ do svÃ½ch
+sÃ­Å¥ovÃ½ch skriptÅ¯.
 .TP
-.B Nástroj:
+.B NÃ¡stroj:
 .B Yast2
 .TP
 .B Soubor:
@@ -77,16 +77,16 @@ WIRELESS_ESSID="Home"
 .br
 WIRELESS_MODE=Ad\-Hoc
 .TP
-.B Dal¹í informace:
+.B DalÅ¡Ã­ informace:
 man ifup
 .br
 info scpm
 .\"
 .\" PCMCIA part
 .\"
-.SH PÙVODNÍ PCMCIA SKRIPTY
-Pokud pou¾íváte pùvodní konfiguraèní skripty z balíèku Pcmcia,
-Mù¾ete pou¾ít tuto metodu.
+.SH PÅ®VODNÃ PCMCIA SKRIPTY
+Pokud pouÅ¾Ã­vÃ¡te pÅ¯vodnÃ­ konfiguraÄnÃ­ skripty z balÃ­Äku Pcmcia,
+MÅ¯Å¾ete pouÅ¾Ã­t tuto metodu.
 .TP
 .B Soubor:
 .I /etc/pcmcia/wireless.opts
@@ -100,12 +100,12 @@ MODE="Ad-Hoc"
 .br
 ;;
 .TP
-.B Dal¹í informace:
+.B DalÅ¡Ã­ informace:
 .I /etc/pcmcia/wireless
 .br
 Soubor
 .IR "PCMCIA.txt" ,
-kterı je souèástí balíèku Wireless Tools
+kterÃ½ je souÄÃ¡stÃ­ balÃ­Äku Wireless Tools
 .\"
 .\" AUTHOR part
 .\"
@@ -116,12 +116,12 @@ Jean Tourrilhes \- jt@hpl.hp.com
 .\"
 .\" TRANSLATION part
 .\"
-.SH PØEKLAD
-Pavel Heimlich \- tropikhajma@seznam.cz, bøezen 2005 (wireless_tools.28pre4).
+.SH PÅ˜EKLAD
+Pavel Heimlich \- tropikhajma@seznam.cz, bÅ™ezen 2005 (wireless_tools.28pre4).
 .\"
 .\" SEE ALSO part
 .\"
-.SH DAL©Í INFORMACE
+.SH DALÅ Ã INFORMACE
 .BR iwconfig (8),
 .BR iwlist (8),
 .BR iwspy (8),

--- a/wireless_tools/fr/ifrename.8
+++ b/wireless_tools/fr/ifrename.8
@@ -3,13 +3,13 @@
 .\"
 .\" Traduction 2004/08/25 Maxime CHARPENNE (voir
 .\" http://www.delafond.org/traducmanfr/)
-.\" 1ère traduction        : version 27-pre25
+.\" 1Ã¨re traduction        : version 27-pre25
 .TH IFRENAME 8 "01 mars 2004" "wireless-tools" "Manuel du programmeur Linux"
 .\"
 .\" NAME part
 .\"
 .SH NOM
-ifrename \- renomme les interfaces réseau basées sur différents critères
+ifrename \- renomme les interfaces rÃ©seau basÃ©es sur diffÃ©rents critÃ¨res
 statiques
 .\"
 .\" SYNOPSIS part
@@ -23,99 +23,99 @@ statiques
 .\"
 .SH DESCRIPTION
 .B Ifrename
-est un outil vous permettant d'assigner un nom cohérent à chacune de vos
-interfaces réseau.
+est un outil vous permettant d'assigner un nom cohÃ©rent Ã  chacune de vos
+interfaces rÃ©seau.
 .PP
-Par défaut, les noms d'interface sont dynamiques, et à chaque interface réseau
-est assigné le premier nom disponible
+Par dÃ©faut, les noms d'interface sont dynamiques, et Ã  chaque interface rÃ©seau
+est assignÃ© le premier nom disponible
 .RI ( eth0 ", " eth1 "...)."
-L'ordre dans lequel les interfaces réseau sont créées peut varier. Pour les
-interfaces fixes («\ built-in interfaces\ »), l'énumération du noyau au
-démarrage peut varier. Pour les interfaces débranchables, l'utilisateur peut les
+L'ordre dans lequel les interfaces rÃ©seau sont crÃ©Ã©es peut varier. Pour les
+interfaces fixes (Â«\ built-in interfaces\ Â»), l'Ã©numÃ©ration du noyau au
+dÃ©marrage peut varier. Pour les interfaces dÃ©branchables, l'utilisateur peut les
 brancher dans n'importe quel ordre.
 .PP
 .B Ifrename
-permet à l'utilisateur de décider quel nom une interface réseau aura.
+permet Ã  l'utilisateur de dÃ©cider quel nom une interface rÃ©seau aura.
 .B Ifrename 
-peut utiliser différents sélecteurs
-.RI "(«\ " selectors "\ »)"
-pour spécifier comment les noms d'interface correspondent aux interfaces réseau
-du système, le plus commun des sélecteurs étant
+peut utiliser diffÃ©rents sÃ©lecteurs
+.RI "(Â«\ " selectors "\ Â»)"
+pour spÃ©cifier comment les noms d'interface correspondent aux interfaces rÃ©seau
+du systÃ¨me, le plus commun des sÃ©lecteurs Ã©tant
 .RI "l'" "adresse MAC"
 de l'interface.
 .PP
 .B Ifrename
-doit être lancé avant que les interfaces ne soient démarrées, raison pour
+doit Ãªtre lancÃ© avant que les interfaces ne soient dÃ©marrÃ©es, raison pour
 laquelle il est surtout utile dans divers scripts (init, hotplug), mais il est
-rarement utilisé directement par l'utilisateur. Par défaut,
+rarement utilisÃ© directement par l'utilisateur. Par dÃ©faut,
 .B ifrename 
-renomme toutes les interfaces système présentes en utilisant les correspondances
-définies dans
+renomme toutes les interfaces systÃ¨me prÃ©sentes en utilisant les correspondances
+dÃ©finies dans
 .IR /etc/iftab .
 .\"
 .\" PARAMETER part
 .\"
-.SH PARAMÈTRES
+.SH PARAMÃˆTRES
 .TP
 .BI "-c " configfile
-Fixe le fichier de configuration à utiliser (par défaut
+Fixe le fichier de configuration Ã  utiliser (par dÃ©faut
 .IR /etc/iftab ).
-Le fichier de configuration définit la correspondance entre les sélecteurs et
-les noms d'interface, et il est décrit dans
+Le fichier de configuration dÃ©finit la correspondance entre les sÃ©lecteurs et
+les noms d'interface, et il est dÃ©crit dans
 .IR iftab (5).
 .br
 Si
 .I configfile
-est «\ -\ », la configuration est lue depuis stdin.
+est Â«\ -\ Â», la configuration est lue depuis stdin.
 .TP
 .B -p
 Sonde (charge) les modules noyau avant de renommer les interfaces. Par
-défaut,
+dÃ©faut,
 .B ifrename 
-vérifie seulement les interfaces déjà chargées, et ne charge pas
-automatiquement les modules noyau requis. Cette option autorise une intégration
-en douceur dans les systèmes qui ne chargent pas les modules avant d'appeler
+vÃ©rifie seulement les interfaces dÃ©jÃ  chargÃ©es, et ne charge pas
+automatiquement les modules noyau requis. Cette option autorise une intÃ©gration
+en douceur dans les systÃ¨mes qui ne chargent pas les modules avant d'appeler
 .BR ifrename .
 .TP
 .B -d
-Active divers bidouillages spécifiques à la
+Active divers bidouillages spÃ©cifiques Ã  la
 .BR Debian .
-Combiné avec
+CombinÃ© avec
 .BR -p ,
-seuls les modules pour les interfaces spécifiées dans
+seuls les modules pour les interfaces spÃ©cifiÃ©es dans
 .I /etc/network/interface
-sont chargés.
+sont chargÃ©s.
 .TP
 .BI "-i " interface
 Renomme seulement
 .RI "l'" interface 
-spécifiée, par opposition à toutes les interfaces présentes sur le système. Le
-nouveau nom de l'interface est affiché.
+spÃ©cifiÃ©e, par opposition Ã  toutes les interfaces prÃ©sentes sur le systÃ¨me. Le
+nouveau nom de l'interface est affichÃ©.
 .TP
 .BI "-n " newname
-Si utilisé avec
+Si utilisÃ© avec
 .IR -i ,
-spécifie le nouveau nom de l'interface. La liste des correspondances depuis le
-fichier de configuration est ignorée. Le nouveau nom peut être un joker
-(«\ wildcard\ ») qui contient une seule '*'.
+spÃ©cifie le nouveau nom de l'interface. La liste des correspondances depuis le
+fichier de configuration est ignorÃ©e. Le nouveau nom peut Ãªtre un joker
+(Â«\ wildcard\ Â») qui contient une seule '*'.
 .TP
 .B -t
-Active l'absorption («\ takover\ ») de nom. Cela permet d'échanger un nom
+Active l'absorption (Â«\ takover\ Â») de nom. Cela permet d'Ã©changer un nom
 d'interface entre deux interfaces ou plus.
 .br
-L'absorption permet à une interface de «\ voler\ » le nom d'une autre
+L'absorption permet Ã  une interface de Â«\ voler\ Â» le nom d'une autre
 interface. Cela fonctionne seulement avec le noyau 2.6.X et si l'autre
-interface est désactivée. En conséquence, ce n'est pas compatible avec Hotplug.
-L'autre interface se voit assigner un nom aléatoire, mais peut être renommée
+interface est dÃ©sactivÃ©e. En consÃ©quence, ce n'est pas compatible avec Hotplug.
+L'autre interface se voit assigner un nom alÃ©atoire, mais peut Ãªtre renommÃ©e
 plus tard avec 'ifrename'.
 .br
-Le nombre d'absorptions est limité pour éviter les boucles circulaires, et donc
-certaines situations d'échanges de noms complexes ne seront pas complètement
-traitées.
+Le nombre d'absorptions est limitÃ© pour Ã©viter les boucles circulaires, et donc
+certaines situations d'Ã©changes de noms complexes ne seront pas complÃ¨tement
+traitÃ©es.
 .br
-Dans tous les cas, l'échange de noms et l'utilisation de cette caractéristique
-sont découragés, et vous êtes invités à choisir des noms uniques et sans
-ambiguïté pour vos interfaces...
+Dans tous les cas, l'Ã©change de noms et l'utilisation de cette caractÃ©ristique
+sont dÃ©couragÃ©s, et vous Ãªtes invitÃ©s Ã  choisir des noms uniques et sans
+ambiguÃ¯tÃ© pour vos interfaces...
 .\"
 .\" AUTHOR part
 .\"
@@ -125,12 +125,12 @@ Jean Tourrilhes \- jt@hpl.hp.com
 .\" TRADUCTION part
 .\"
 .SH TRADUCTION
-Maxime CHARPENNE, août 2004 (wireless_tools.27-pre25).
+Maxime CHARPENNE, aoÃ»t 2004 (wireless_tools.27-pre25).
 .\"
 .\" AVERTISSEMENT part
 .\"
 .SH AVERTISSEMENT SUR LA TRADUCTION
-Il est possible que cette traduction soit imparfaite ou périmée. En cas de
+Il est possible que cette traduction soit imparfaite ou pÃ©rimÃ©e. En cas de
 doute, veuillez vous reporter au document original en langue anglaise fourni
 avec le programme.
 .\"

--- a/wireless_tools/fr/iftab.5
+++ b/wireless_tools/fr/iftab.5
@@ -3,154 +3,154 @@
 .\"
 .\" Traduction 2004/08/25 Maxime CHARPENNE (voir
 .\" http://www.delafond.org/traducmanfr/)
-.\" 1ère traduction        : version 27-pre25
+.\" 1Ã¨re traduction        : version 27-pre25
 .\"
 .TH IFTAB 5 "01 mars 2004" "wireless-tools" "Manuel du Programmeur Linux"
 .\"
 .\" NAME part
 .\"
 .SH NOM
-iftab \- informations statiques sur les interfaces réseau
+iftab \- informations statiques sur les interfaces rÃ©seau
 .\"
 .\" DESCRIPTION part
 .\"
 .SH DESCRIPTION
 Le fichier
 .B /etc/iftab
-contient de l'information descriptive à propos des diverses interfaces réseau.
+contient de l'information descriptive Ã  propos des diverses interfaces rÃ©seau.
 .B iftab
-n'est utilisé que par le programme
+n'est utilisÃ© que par le programme
 .IR ifrename (8)
-pour assigner un nom d'interface réseau cohérent à chaque interface réseau.
+pour assigner un nom d'interface rÃ©seau cohÃ©rent Ã  chaque interface rÃ©seau.
 .PP
 .B /etc/iftab
-définit un ensemble de
-.RI "correspondances («\ " mappings "\ »)."
-Chaque correspondance contient un nom d'interface et un ensemble de sélecteurs
-(«\ selectors\ »). Les sélecteurs permettent à
+dÃ©finit un ensemble de
+.RI "correspondances (Â«\ " mappings "\ Â»)."
+Chaque correspondance contient un nom d'interface et un ensemble de sÃ©lecteurs
+(Â«\ selectors\ Â»). Les sÃ©lecteurs permettent Ã 
 .B ifrename
-d'identifier chaque interface réseau du système. Si une interface réseau
-correspond à tous les descripteurs d'une correspondance,
+d'identifier chaque interface rÃ©seau du systÃ¨me. Si une interface rÃ©seau
+correspond Ã  tous les descripteurs d'une correspondance,
 .B ifrename
-essaye de changer le nom de l'interface par le nom de l'interface donné dans la
+essaye de changer le nom de l'interface par le nom de l'interface donnÃ© dans la
 correspondance.
 .\"
 .\" MAPPINGS part
 .\"
-.SH CORRESPONDANCES («\ MAPPINGS\ »)
-Chaque correspondance est décrite sur une ligne distincte, elle commence avec
+.SH CORRESPONDANCES (Â«\ MAPPINGS\ Â»)
+Chaque correspondance est dÃ©crite sur une ligne distincte, elle commence avec
 .IR "interface name" " (nom d'interface),"
 et contient un ensemble de
-.RI "descripteurs («\ " descriptors "\ »),"
-séparés par des espaces ou des tabulations.
+.RI "descripteurs (Â«\ " descriptors "\ Â»),"
+sÃ©parÃ©s par des espaces ou des tabulations.
 .PP
 La relation entre les descripteurs d'une correspondance est un
 .IR "et logique" .
-Une correspondance s'applique à une interface réseau seulement si tous les
-descripteurs s'appliquent. Si une interface réseau ne supporte pas un
-descripteur particulier, elle ne s'appliquera à aucune correspondance qui
+Une correspondance s'applique Ã  une interface rÃ©seau seulement si tous les
+descripteurs s'appliquent. Si une interface rÃ©seau ne supporte pas un
+descripteur particulier, elle ne s'appliquera Ã  aucune correspondance qui
 utilise ce descripteur.
 .PP
 Si vous voulez utiliser des descripteurs alternatifs pour un nom d'interface
-(ou logique), spécifiez deux correspondances différentes avec le même nom
+(ou logique), spÃ©cifiez deux correspondances diffÃ©rentes avec le mÃªme nom
 d'interface (une par ligne).
 .B Ifrename
-utilise toujours la première correspondance en commençant par la
+utilise toujours la premiÃ¨re correspondance en commenÃ§ant par la
 .I fin
 de
 .BR iftab ,
-donc les correspondances les plus restrictives devraient être définies en
+donc les correspondances les plus restrictives devraient Ãªtre dÃ©finies en
 dernier.
 .\"
 .\" INTERFACE NAME part
 .\"
 .SH NOM D'INTERFACE
-La première partie de chaque correspondance est un nom d'interface. Si une
-interface réseau correspond à tous les descripteurs d'une correspondance,
+La premiÃ¨re partie de chaque correspondance est un nom d'interface. Si une
+interface rÃ©seau correspond Ã  tous les descripteurs d'une correspondance,
 .B ifrename
-essaye de changer le nom de l'interface par le nom de l'interface donné dans la
+essaye de changer le nom de l'interface par le nom de l'interface donnÃ© dans la
 correspondance.
 .PP
 Le nom de l'interface d'une correspondance est soit un nom d'interface complet
 (comme
 .IR eth2 " ou " wlan0 )
-ou un motif de nom d'interface contenant un seul caractère joker (comme
+ou un motif de nom d'interface contenant un seul caractÃ¨re joker (comme
 .IR eth* " ou " wlan* ).
-Dans le cas d'un caractère joker («\ wildcard\ »), le noyau remplace le
-caractère '*' par le plus petit entier disponible faisant un nom d'interface
+Dans le cas d'un caractÃ¨re joker (Â«\ wildcard\ Â»), le noyau remplace le
+caractÃ¨re '*' par le plus petit entier disponible faisant un nom d'interface
 unique.
 .\"
 .\" DESCRIPTORS part
 .\"
-.SH DESCRIPTEURS («\ DESCRIPTORS\ »)
-Chaque descripteur est composé d'un nom de descripteur et d'une valeur de
-descripteur. Les descripteurs définissent un attribut statique d'une interface
-réseau, le but étant d'identifier de manière unique chaque périphérique.
+.SH DESCRIPTEURS (Â«\ DESCRIPTORS\ Â»)
+Chaque descripteur est composÃ© d'un nom de descripteur et d'une valeur de
+descripteur. Les descripteurs dÃ©finissent un attribut statique d'une interface
+rÃ©seau, le but Ã©tant d'identifier de maniÃ¨re unique chaque pÃ©riphÃ©rique.
 .PP
-La plupart des utilisateurs n'utiliseront que le sélecteur
+La plupart des utilisateurs n'utiliseront que le sÃ©lecteur
 .BR mac ,
-les autres sélecteurs étant pour une configuration plus spécialisée.
+les autres sÃ©lecteurs Ã©tant pour une configuration plus spÃ©cialisÃ©e.
 .TP
 .BI mac " adresse mac"
-Correspond à l'Adresse MAC de l'interface avec l'adresse MAC spécifiée.
-L'adresse MAC de l'interface peut être montrée en utilisant
+Correspond Ã  l'Adresse MAC de l'interface avec l'adresse MAC spÃ©cifiÃ©e.
+L'adresse MAC de l'interface peut Ãªtre montrÃ©e en utilisant
 .IR ifconfig (8)
 ou
 .IR ip (8).
-L'adresse MAC spécifiée peut contenir une '*' pour la correspondance joker
-(«\ wildcard matching\ »).
+L'adresse MAC spÃ©cifiÃ©e peut contenir une '*' pour la correspondance joker
+(Â«\ wildcard matching\ Â»).
 .br
-C'est le plus commun des sélecteurs, vu que chaque interface possède une
-adresse MAC unique, ce qui permet de les identifier sans ambiguïté.
+C'est le plus commun des sÃ©lecteurs, vu que chaque interface possÃ¨de une
+adresse MAC unique, ce qui permet de les identifier sans ambiguÃ¯tÃ©.
 .TP
 .BI arp " arp type"
-Fait correspondre le Type ARP («\ ARP Type\ ») (aussi appelé «\ Link Type\ »)
-de l'interface avec le type ARP spécifié. Le Type ARP de l'interface peut être
-montré en utilisant
+Fait correspondre le Type ARP (Â«\ ARP Type\ Â») (aussi appelÃ© Â«\ Link Type\ Â»)
+de l'interface avec le type ARP spÃ©cifiÃ©. Le Type ARP de l'interface peut Ãªtre
+montrÃ© en utilisant
 .IR ifconfig (8)
 ou
 .IR ip (8).
 .br
-Ce sélecteur est utile quand un pilote crée plusieurs interfaces réseau pour
-une seule carte réseau.
+Ce sÃ©lecteur est utile quand un pilote crÃ©e plusieurs interfaces rÃ©seau pour
+une seule carte rÃ©seau.
 .TP
 .BI driver " driver name"
-Fait correspondre le Nom de Pilote («\ Driver Name\ ») de l'interface avec le
-nom de pilote spécifié. Le Nom de Pilote de l'interface peut être montré en
+Fait correspondre le Nom de Pilote (Â«\ Driver Name\ Â») de l'interface avec le
+nom de pilote spÃ©cifiÃ©. Le Nom de Pilote de l'interface peut Ãªtre montrÃ© en
 utilisant
 .IR "ethtool -i" (8).
 .TP
 .BI businfo " bus information"
-Fait correspondre l'Information de Bus («\ Bus Information\ ») de l'interface
-avec l'information de bus spécifiée. L'Information de Bus de l'interface peut
-être montrée en utilisant
+Fait correspondre l'Information de Bus (Â«\ Bus Information\ Â») de l'interface
+avec l'information de bus spÃ©cifiÃ©e. L'Information de Bus de l'interface peut
+Ãªtre montrÃ©e en utilisant
 .IR "ethtool -i" (8).
 .TP
 .BI baseaddress " base address"
-Fait correspondre l'Adresse de Base («\ Base Address\ ») de l'interface avec
-l'adresse de base spécifiée. L'Adresse de Base de l'interface peut être montrée
+Fait correspondre l'Adresse de Base (Â«\ Base Address\ Â») de l'interface avec
+l'adresse de base spÃ©cifiÃ©e. L'Adresse de Base de l'interface peut Ãªtre montrÃ©e
 en utilisant
 .IR ifconfig (8).
 .br
-Ce sélecteur n'est utile que pour les cartes ISA et EISA car la plupart des
+Ce sÃ©lecteur n'est utile que pour les cartes ISA et EISA car la plupart des
 cartes utilisent l'allocation dynamique pour l'Adresse de Base.
 .TP
 .BI irq " irq line"
 Fait correspondre la Ligne IRQ (interruption) de l'interface avec la ligne IRQ
-spécifiée. La Ligne IRQ de l'interface peut être montrée en utilisant
+spÃ©cifiÃ©e. La Ligne IRQ de l'interface peut Ãªtre montrÃ©e en utilisant
 .IR ifconfig (8).
 .br
-Ce sélecteur n'est habituellement pas suffisant pour identifier de manière
-unique une interface, car les Lignes IRQ peuvent être partagées.
+Ce sÃ©lecteur n'est habituellement pas suffisant pour identifier de maniÃ¨re
+unique une interface, car les Lignes IRQ peuvent Ãªtre partagÃ©es.
 .TP
 .BI iwproto " wireless protocol"
 Fait correspondre le Protocole Wireless de l'interface avec le protocole
-wireless spécifié. Le Protocole Wireless de l'interface peut être montré
+wireless spÃ©cifiÃ©. Le Protocole Wireless de l'interface peut Ãªtre montrÃ©
 en utilisant
 .IR iwconfig (8).
 .br
-Ce sélecteur n'est valable que pour les interfaces wireless et n'est pas
-suffisant pour en identifier une de manière unique.
+Ce sÃ©lecteur n'est valable que pour les interfaces wireless et n'est pas
+suffisant pour en identifier une de maniÃ¨re unique.
 .\"
 .\" EXAMPLE part
 .\"
@@ -173,12 +173,12 @@ Jean Tourrilhes \- jt@hpl.hp.com
 .\" TRADUCTION part
 .\"
 .SH TRADUCTION
-Maxime CHARPENNE, août 2004 (wireless_tools.27-pre25).
+Maxime CHARPENNE, aoÃ»t 2004 (wireless_tools.27-pre25).
 .\"
 .\" AVERTISSEMENT part
 .\"
 .SH AVERTISSEMENT SUR LA TRADUCTION
-Il est possible que cette traduction soit imparfaite ou périmée. En cas de
+Il est possible que cette traduction soit imparfaite ou pÃ©rimÃ©e. En cas de
 doute, veuillez vous reporter au document original en langue anglaise fourni
 avec le programme.
 .\"

--- a/wireless_tools/fr/iwconfig.8
+++ b/wireless_tools/fr/iwconfig.8
@@ -3,17 +3,17 @@
 .\"
 .\" Traduction 2003/07/15 Maxime CHARPENNE (voir
 .\" http://www.delafond.org/traducmanfr/)
-.\" 1ère traduction        : version 26
-.\" Mise à jour 2004/01/28 : version 27-pre9 (beta)
-.\" Mise à jour 2004/02/26 : version 27-pre11 (alpha)
-.\" Mise à jour 2004/08/23 : version 27-pre25
+.\" 1Ã¨re traduction        : version 26
+.\" Mise Ã  jour 2004/01/28 : version 27-pre9 (beta)
+.\" Mise Ã  jour 2004/02/26 : version 27-pre11 (alpha)
+.\" Mise Ã  jour 2004/08/23 : version 27-pre25
 .\"
 .TH IWCONFIG 8 "22 juin 2004" "wireless-tools" "Manuel du programmeur Linux"
 .\"
 .\" NAME part
 .\"
 .SH NOM
-iwconfig \- configure une interface réseau sans-fil (wireless)
+iwconfig \- configure une interface rÃ©seau sans-fil (wireless)
 .\"
 .\" SYNOPSIS part
 .\"
@@ -38,39 +38,39 @@ iwconfig \- configure une interface réseau sans-fil (wireless)
 .\"
 .SH DESCRIPTION
 .B Iwconfig
-est similaire à
+est similaire Ã 
 .IR ifconfig (8),
-mais est dédié aux interfaces wireless. Il est utilisé pour manier les
-paramètres des interfaces réseaux qui sont spécifiques aux opérations wireless
-(par exemple\ : la fréquence).
+mais est dÃ©diÃ© aux interfaces wireless. Il est utilisÃ© pour manier les
+paramÃ¨tres des interfaces rÃ©seaux qui sont spÃ©cifiques aux opÃ©rations wireless
+(par exemple\ : la frÃ©quence).
 .B Iwconfig
-peut aussi être utilisé pour afficher ces paramètres, et les statistiques
+peut aussi Ãªtre utilisÃ© pour afficher ces paramÃ¨tres, et les statistiques
 concernant le sans fil (extraites de
 .IR /proc/net/wireless ).
 .PP
-Tous ces paramètres et statistiques dépendent du matériel. Chaque pilote ne
-fournira que quelques uns d'entre eux en fonction du support matériel, et
-l'étendue des valeurs peut changer. Veuillez vous référer aux pages man de
-chaque matériel pour plus de détails.
+Tous ces paramÃ¨tres et statistiques dÃ©pendent du matÃ©riel. Chaque pilote ne
+fournira que quelques uns d'entre eux en fonction du support matÃ©riel, et
+l'Ã©tendue des valeurs peut changer. Veuillez vous rÃ©fÃ©rer aux pages man de
+chaque matÃ©riel pour plus de dÃ©tails.
 .\"
 .\" PARAMETER part
 .\"
-.SH PARAMÈTRES
+.SH PARAMÃˆTRES
 .TP
 .B essid
 Positionne le ESSID ( ou Network Name - pour certains produits, il peut aussi
-être désigné comme Domain ID). L'ESSID est utilisé pour identifier les cellules
-qui font partie du même réseau virtuel.
+Ãªtre dÃ©signÃ© comme Domain ID). L'ESSID est utilisÃ© pour identifier les cellules
+qui font partie du mÃªme rÃ©seau virtuel.
 .br
-Par opposition à l'adresse de l'AP ou au NWID qui définissent une seule cellule,
-l'ESSID définit un groupe de cellules connectées via des répéteurs ou via
-l'infrastructure, où l'utilisateur peut «\ roamer\ » ou errer de manière
-transprente (c.-à-d. changer de cellule sans perdre sa connexion).
+Par opposition Ã  l'adresse de l'AP ou au NWID qui dÃ©finissent une seule cellule,
+l'ESSID dÃ©finit un groupe de cellules connectÃ©es via des rÃ©pÃ©teurs ou via
+l'infrastructure, oÃ¹ l'utilisateur peut Â«\ roamer\ Â» ou errer de maniÃ¨re
+transprente (c.-Ã -d. changer de cellule sans perdre sa connexion).
 .br
-Avec certaines cartes, vous pouvez désactiver le contrôle du ESSID (ESSID
+Avec certaines cartes, vous pouvez dÃ©sactiver le contrÃ´le du ESSID (ESSID
 promiscuous) avec
 .IR off " ou " any " (et " on
-pour le réactiver).
+pour le rÃ©activer).
 .br
 .B Exemples :
 .br
@@ -79,18 +79,18 @@ pour le réactiver).
 .I "	iwconfig eth0 essid ""Mon Reseau""
 .TP
 .BR nwid / domain
-Positionne le Network ID (pour certains produits, il peut aussi être appelé
-Domain ID). Comme tous les réseaux sans fil adjacents partagent le même médium,
-ce paramètre est utilisé pour les différencier (créer des réseaux logiques
-colocalisés) et pour identifier des noeuds appartenant à la même cellule.
+Positionne le Network ID (pour certains produits, il peut aussi Ãªtre appelÃ©
+Domain ID). Comme tous les rÃ©seaux sans fil adjacents partagent le mÃªme mÃ©dium,
+ce paramÃ¨tre est utilisÃ© pour les diffÃ©rencier (crÃ©er des rÃ©seaux logiques
+colocalisÃ©s) et pour identifier des noeuds appartenant Ã  la mÃªme cellule.
 .br
-Ce paramètre est seulement utilisé par les matériels antérieurs à 802.11, la
+Ce paramÃ¨tre est seulement utilisÃ© par les matÃ©riels antÃ©rieurs Ã  802.11, la
 norme 802.11 se servant du ESSID et de l'adresse de l'AP pour cette fonction.
 .br
-Avec certaines cartes, vous pouvez désactiver le contrôle du Network ID (NWID
+Avec certaines cartes, vous pouvez dÃ©sactiver le contrÃ´le du Network ID (NWID
 promiscuous) avec
 .IR off " (et " on
-pour le réactiver).
+pour le rÃ©activer).
 .br
 .B Exemples :
 .br
@@ -99,18 +99,18 @@ pour le réactiver).
 .I "	iwconfig eth0 nwid off"
 .TP
 .BR freq / channel
-Positionne la fréquence d'exploitation ou canal du périphérique. Une valeur
-inférieure à 1\ 000 indique un numéro de canal, une valeur supérieure à 1\ 000
-est une fréquence en Hz. Vous pouvez ajouter le suffixe k, M ou G à la valeur
-(par exemple, «\ 2.46G\ » pour la fréquence 2,46\ GHz), ou ajouter suffisamment
-de «\ 0\ ».
+Positionne la frÃ©quence d'exploitation ou canal du pÃ©riphÃ©rique. Une valeur
+infÃ©rieure Ã  1\ 000 indique un numÃ©ro de canal, une valeur supÃ©rieure Ã  1\ 000
+est une frÃ©quence en Hz. Vous pouvez ajouter le suffixe k, M ou G Ã  la valeur
+(par exemple, Â«\ 2.46G\ Â» pour la frÃ©quence 2,46\ GHz), ou ajouter suffisamment
+de Â«\ 0\ Â».
 .br
-Les canaux sont habituellement numérotés à partir de 1, et vous pouvez utiliser
+Les canaux sont habituellement numÃ©rotÃ©s Ã  partir de 1, et vous pouvez utiliser
 .IR iwlist (8)
-pour obtenir le nombre total de canaux, lister les fréquences disponibles, et
-afficher le fréquence courante comme un canal.
-Suivants les réglementations, certaines fréquences/canaux peuvent ne pas
-être disponibles.
+pour obtenir le nombre total de canaux, lister les frÃ©quences disponibles, et
+afficher le frÃ©quence courante comme un canal.
+Suivants les rÃ©glementations, certaines frÃ©quences/canaux peuvent ne pas
+Ãªtre disponibles.
 .br
 .B Exemples :
 .br
@@ -121,36 +121,36 @@ Suivants les réglementations, certaines fréquences/canaux peuvent ne pas
 .I "	iwconfig eth0 channel 3"
 .TP
 .B sens
-Positionne le seuil de sensibilité. C'est le niveau de signal le plus bas pour
-lequel le matériel essaye de réceptionner un paquet, les signaux plus bas sont
-ignorés. Ceci est utilisé pour éviter de recevoir le bruit de fond, donc vous
+Positionne le seuil de sensibilitÃ©. C'est le niveau de signal le plus bas pour
+lequel le matÃ©riel essaye de rÃ©ceptionner un paquet, les signaux plus bas sont
+ignorÃ©s. Ceci est utilisÃ© pour Ã©viter de recevoir le bruit de fond, donc vous
 devriez le positionner en fonction du niveau de bruit moyen. Les valeurs
-positives sont supposées être les valeurs brutes utilisées par le matériel ou
-un pourcentage, les valeurs négatives sont supposées être des dBm.
+positives sont supposÃ©es Ãªtre les valeurs brutes utilisÃ©es par le matÃ©riel ou
+un pourcentage, les valeurs nÃ©gatives sont supposÃ©es Ãªtre des dBm.
 .br
-Avec certains matériels, ce paramètre contrôle aussi le seuil de report
-(defer threshold) (signal le plus faible pour lequel le matériel considère le
-canal occupé) et le seuil de cession (handover threshold) (niveau de signal pour
-lequel le matériel commence à chercher un nouveau Point d'Accès).
+Avec certains matÃ©riels, ce paramÃ¨tre contrÃ´le aussi le seuil de report
+(defer threshold) (signal le plus faible pour lequel le matÃ©riel considÃ¨re le
+canal occupÃ©) et le seuil de cession (handover threshold) (niveau de signal pour
+lequel le matÃ©riel commence Ã  chercher un nouveau Point d'AccÃ¨s).
 .br
 .B Exemple :
 .br
 .I "	iwconfig eth0 sens -80"
 .TP
 .B mode
-Positionne le mode de fonctionnement du matériel, qui dépend de la topologie du
-réseau. Le mode peut être
+Positionne le mode de fonctionnement du matÃ©riel, qui dÃ©pend de la topologie du
+rÃ©seau. Le mode peut Ãªtre
 .I Ad-Hoc
-(réseau composé d'une seule cellule et sans Point d'Accès),
+(rÃ©seau composÃ© d'une seule cellule et sans Point d'AccÃ¨s),
 .I Managed
-(un noeud se connecte à un réseau composé de plusieurs Points d'Accès, avec
+(un noeud se connecte Ã  un rÃ©seau composÃ© de plusieurs Points d'AccÃ¨s, avec
 roaming ou errance),
 .I Master
-(le noeud est le maître qui synchronise ou agit comme un Point d'Accès),
+(le noeud est le maÃ®tre qui synchronise ou agit comme un Point d'AccÃ¨s),
 .I Repeater
-(le noeud transmet les paquets entre les autres n½uds wireless),
+(le noeud transmet les paquets entre les autres nÂ½uds wireless),
 .I Secondary
-(le noeud agit comme un maître/répéteur supplémentaire),
+(le noeud agit comme un maÃ®tre/rÃ©pÃ©teur supplÃ©mentaire),
 .I Monitor
 (le noeud agit comme un moniteur passif et ne fait que recevoir des paquets) ou
 .IR Auto .
@@ -162,19 +162,19 @@ roaming ou errance),
 .I "	iwconfig eth0 mode Ad-Hoc"
 .TP
 .B ap
-Force la carte à s'enregistrer auprès du Point d'Accès donné par l'adresse,
-si c'est possible. Quand la qualité de la connexion devient trop mauvaise,
-le pilote peut revenir en mode automatique (la carte sélectionne le meilleur
-Point d'Accès à portée).
+Force la carte Ã  s'enregistrer auprÃ¨s du Point d'AccÃ¨s donnÃ© par l'adresse,
+si c'est possible. Quand la qualitÃ© de la connexion devient trop mauvaise,
+le pilote peut revenir en mode automatique (la carte sÃ©lectionne le meilleur
+Point d'AccÃ¨s Ã  portÃ©e).
 .br
 Vous pouvez aussi utiliser
 .I off
-pour réactiver le mode automatique sans changer le Point d'Accès courant,
+pour rÃ©activer le mode automatique sans changer le Point d'AccÃ¨s courant,
 ou vous pouvez utiliser
 .I any
 ou
 .I auto
-pour forcer la carte à se ré associer avec le meilleur Point d'Accès courant.
+pour forcer la carte Ã  se rÃ© associer avec le meilleur Point d'AccÃ¨s courant.
 .br
 .B Exemple :
 .br
@@ -186,8 +186,8 @@ pour forcer la carte à se ré associer avec le meilleur Point d'Accès courant.
 .TP
 .BR nick [name]
 Positionne le surnom (nickname), ou nom de station. Quelques produits
-802.11 le définissent, mais il n'est pas utilisé dans la mesure où les
-protocoles les plus usités (MAC, IP, TCP) ne s'en servent pas en l'état.
+802.11 le dÃ©finissent, mais il n'est pas utilisÃ© dans la mesure oÃ¹ les
+protocoles les plus usitÃ©s (MAC, IP, TCP) ne s'en servent pas en l'Ã©tat.
 Seuls quelques outils de diagnostic peuvent l'utiliser.
 .br
 .B Exemple :
@@ -195,24 +195,24 @@ Seuls quelques outils de diagnostic peuvent l'utiliser.
 .I "	iwconfig eth0 nickname ""My Linux Node""
 .TP
 .BR rate / bit [rate]
-Pour les cartes supportant plusieurs débits, positionne le débit en b/s. Le
-débit est la vitesse à laquelle les bits sont transmis sur le médium, la
-vitesse du lien pour l'utilisateur est inférieure à cause du partage du médium
-et des diverses entêtes.
+Pour les cartes supportant plusieurs dÃ©bits, positionne le dÃ©bit en b/s. Le
+dÃ©bit est la vitesse Ã  laquelle les bits sont transmis sur le mÃ©dium, la
+vitesse du lien pour l'utilisateur est infÃ©rieure Ã  cause du partage du mÃ©dium
+et des diverses entÃªtes.
 .br
-Vous pouvez ajouter le suffixe k, M ou G à la valeur (multiplicateur décimal\ :
-10^3, 10^6 et 10^9\ b/s), ou ajouter suffisamment de «\ 0\ ». Les valeurs
-en-dessous de 1000 sont spécifiques à la carte, habituellement un index de la
-liste des débit supportés. Utilisez
+Vous pouvez ajouter le suffixe k, M ou G Ã  la valeur (multiplicateur dÃ©cimal\ :
+10^3, 10^6 et 10^9\ b/s), ou ajouter suffisamment de Â«\ 0\ Â». Les valeurs
+en-dessous de 1000 sont spÃ©cifiques Ã  la carte, habituellement un index de la
+liste des dÃ©bit supportÃ©s. Utilisez
 .I auto
-pour sélectionner le mode débit automatique (repli à un débit moindre pour
-les canaux bruités), ce qui est le mode par défaut pour la plupart des cartes,
+pour sÃ©lectionner le mode dÃ©bit automatique (repli Ã  un dÃ©bit moindre pour
+les canaux bruitÃ©s), ce qui est le mode par dÃ©faut pour la plupart des cartes,
 et
 .I fixed
-pour revenir à des paramètres fixes. Si vous spécifiez une valeur de débit
+pour revenir Ã  des paramÃ¨tres fixes. Si vous spÃ©cifiez une valeur de dÃ©bit
 et ajoutez
 .IR auto ,
-le driver utilisera tous les débits inférieurs et égaux à cette valeur.
+le driver utilisera tous les dÃ©bits infÃ©rieurs et Ã©gaux Ã  cette valeur.
 .br
 .B Exemples :
 .br
@@ -223,13 +223,13 @@ le driver utilisera tous les débits inférieurs et égaux à cette valeur.
 .I "	iwconfig eth0 rate 5.5M auto"
 .TP
 .BR rts [_threshold]
-RTS/CTS ajoute une «\ poignée de main\ » avant chaque transmission de paquet
-pour être sûr que le canal est libre. Cela ajoute des entêtes (NDT\ : données de
-gestion), mais augmente les performances en cas de n½uds cachés ou
-d'un grand nombre de noeuds actifs. Ce paramètre fixe la taille du plus petit
-paquet pour lequel le noeud envoie un RTS\ ; une valeur égale à la taille
-maximale des paquets inhibe ce mécanisme. Vous pouvez aussi positionner
-ce paramètre sur
+RTS/CTS ajoute une Â«\ poignÃ©e de main\ Â» avant chaque transmission de paquet
+pour Ãªtre sÃ»r que le canal est libre. Cela ajoute des entÃªtes (NDT\ : donnÃ©es de
+gestion), mais augmente les performances en cas de nÂ½uds cachÃ©s ou
+d'un grand nombre de noeuds actifs. Ce paramÃ¨tre fixe la taille du plus petit
+paquet pour lequel le noeud envoie un RTS\ ; une valeur Ã©gale Ã  la taille
+maximale des paquets inhibe ce mÃ©canisme. Vous pouvez aussi positionner
+ce paramÃ¨tre sur
 .IR auto ", " fixed " ou " off .
 .br
 .B Exemples :
@@ -239,13 +239,13 @@ ce paramètre sur
 .I "	iwconfig eth0 rts off"
 .TP
 .BR frag [mentation_threshold]
-La fragmentation permet de découper un paquet IP en une série de plus petits
-fragments transmis par le médium. Dans la plupart des cas, cela ajoute des
-entêtes, mais dans un environnement très bruité, cela réduit les coûts de
-transmission dus aux erreurs et permet aux paquets d'être acheminés malgré
-des séries d'interférences. Ce paramètre fixe la taille de fragment maximale\ ;
-une valeur égale à la taille maximale de paquet désactive ce procédé. Vous
-pouvez aussi mettre ce paramètre à
+La fragmentation permet de dÃ©couper un paquet IP en une sÃ©rie de plus petits
+fragments transmis par le mÃ©dium. Dans la plupart des cas, cela ajoute des
+entÃªtes, mais dans un environnement trÃ¨s bruitÃ©, cela rÃ©duit les coÃ»ts de
+transmission dus aux erreurs et permet aux paquets d'Ãªtre acheminÃ©s malgrÃ©
+des sÃ©ries d'interfÃ©rences. Ce paramÃ¨tre fixe la taille de fragment maximale\ ;
+une valeur Ã©gale Ã  la taille maximale de paquet dÃ©sactive ce procÃ©dÃ©. Vous
+pouvez aussi mettre ce paramÃ¨tre Ã 
 .IR auto ", " fixed " ou " off .
 .br
 .B Exemples :
@@ -255,44 +255,44 @@ pouvez aussi mettre ce paramètre à
 .I "	iwconfig eth0 frag off"
 .TP
 .BR key / enc [ryption]
-Utilisé pour manipuler les clefs de cryptage ou brouillage et le mode de
-sécurité.
+UtilisÃ© pour manipuler les clefs de cryptage ou brouillage et le mode de
+sÃ©curitÃ©.
 .br
 Pour mettre la clef courante de cryptage, il suffit d'entrer la clef
-en hexadécimal telle que
+en hexadÃ©cimal telle que
 .IR XXXX-XXXX-XXXX-XXXX " ou " XXXXXXXX .
-Pour entrer une autre clef que la clef courante, ajoutez (au début ou à la
+Pour entrer une autre clef que la clef courante, ajoutez (au dÃ©but ou Ã  la
 fin)
 .I [index]
-à la clef elle-même (cela ne changera pas la clef active). Vous pouvez aussi
-entrer la clef comme une chaîne ASCII en utilisant le préfixe
+Ã  la clef elle-mÃªme (cela ne changera pas la clef active). Vous pouvez aussi
+entrer la clef comme une chaÃ®ne ASCII en utilisant le prÃ©fixe
 .IR s: .
-Les phrases en tant que mot de passe ne sont actuellement pas supportées.
+Les phrases en tant que mot de passe ne sont actuellement pas supportÃ©es.
 .br
-Pour changer la clef active parmi les clefs déjà entrées, il suffit d'entrer
+Pour changer la clef active parmi les clefs dÃ©jÃ  entrÃ©es, il suffit d'entrer
 .RI l' "[index]"
 (sans entrer de valeur de clef).
 .br
 .IR off " et " on
-désactive et réactive le cryptage.
+dÃ©sactive et rÃ©active le cryptage.
 .br
-Le mode de sécurité peut être
+Le mode de sÃ©curitÃ© peut Ãªtre
 .I open
 ou
 .IR restricted ,
-et sa signification dépend de la carte utilisée. Avec la plupart des cartes,
+et sa signification dÃ©pend de la carte utilisÃ©e. Avec la plupart des cartes,
 le mode
 .I open
-n'utilise pas d'authentification et la carte accepte des sessions non cryptées,
+n'utilise pas d'authentification et la carte accepte des sessions non cryptÃ©es,
 alors que le mode
 .I restricted
-n'accepte que des sessions cryptées et la carte utilisera l'authentification
+n'accepte que des sessions cryptÃ©es et la carte utilisera l'authentification
 si disponible.
 .br
 Si vous avez besoin de mettre plusieurs clefs, ou de mettre une clef et de
-changer la clef active, vous avez besoin d'utiliser des instructions à clefs
+changer la clef active, vous avez besoin d'utiliser des instructions Ã  clefs
 .RB ( "key" )
-multiples. Les arguments peuvent être mis dans n'importe quel ordre, le
+multiples. Les arguments peuvent Ãªtre mis dans n'importe quel ordre, le
 dernier sera prioritaire.
 .br
 .B Exemples :
@@ -314,29 +314,29 @@ dernier sera prioritaire.
 .I "	iwconfig eth0 key 01-23 key 45-67 [4] key [4]"
 .TP
 .BR power
-Utilisé pour manipuler les paramètres et le mode du procédé de gestion
-d'énergie.
+UtilisÃ© pour manipuler les paramÃ¨tres et le mode du procÃ©dÃ© de gestion
+d'Ã©nergie.
 .br
-Pour fixer la période entre les éveils, entrez la
+Pour fixer la pÃ©riode entre les Ã©veils, entrez la
 .IR "period `valeur'" .
 Pour fixer la temporisation avant le retour en veille, entrez la
 .IR "timeout `valeur'" .
 Vous pouvez aussi ajouter les modificateurs
 .IR min " et " max ".
-Par défaut, ces valeurs sont exprimées en secondes, ajoutez le suffixe m ou u
-pour spécifier les valeurs en millisecondes ou microsecondes. Parfois, ces
-valeurs sont sans unité (nombre de périodes de beacon, dwell ou similaire).
+Par dÃ©faut, ces valeurs sont exprimÃ©es en secondes, ajoutez le suffixe m ou u
+pour spÃ©cifier les valeurs en millisecondes ou microsecondes. Parfois, ces
+valeurs sont sans unitÃ© (nombre de pÃ©riodes de beacon, dwell ou similaire).
 .br
 .IR off " et " on
-désactive et réactive la gestion d'énergie. Enfin, vous pouvez mettre la
-gestion d'énergie en mode
+dÃ©sactive et rÃ©active la gestion d'Ã©nergie. Enfin, vous pouvez mettre la
+gestion d'Ã©nergie en mode
 .I all
-(reçoit tous les paquets),
+(reÃ§oit tous les paquets),
 .I unicast
-(reçoit seulement les paquets unicast, ignore les paquets multicast et de
+(reÃ§oit seulement les paquets unicast, ignore les paquets multicast et de
 broadcast) et
 .I multicast
-(reçoit seulement les paquets multicast et de broadcast, ignore l'unicast).
+(reÃ§oit seulement les paquets multicast et de broadcast, ignore l'unicast).
 .br
 .B Exemples :
 .br
@@ -351,20 +351,20 @@ broadcast) et
 .I "	iwconfig eth0 power min period 2 power max period 4"
 .TP
 .BR txpower
-Pour les cartes supportant plusieurs puissances de transmission, règle la
+Pour les cartes supportant plusieurs puissances de transmission, rÃ¨gle la
 puissance de transmission en dBm. Si
 .I W
 est la puissance en Watt, la puissance en dBm est
 .IR "P\ =\ 30\ +\ 10.log(W)" .
-Si la valeur est post fixée par
+Si la valeur est post fixÃ©e par
 .IR mW ,
 elle sera automatiquement convertie en dBm.
 .br
 De plus,
 .IR on " et " off
-active et désactive la radio, et
+active et dÃ©sactive la radio, et
 .IR auto " et " fixed
-active et désactive le contrôle de puissance (si ces fonctions sont
+active et dÃ©sactive le contrÃ´le de puissance (si ces fonctions sont
 disponibles).
 .br
 .B Exemples :
@@ -378,28 +378,28 @@ disponibles).
 .I "	iwconfig eth0 txpower off"
 .TP
 .BR retry
-La plupart des cartes supportent les retransmissions MAC (contrôle d'accès
-au médium), et certaines permettent le paramétrage du mécanisme des tentatives
-(en cas d'échec).
+La plupart des cartes supportent les retransmissions MAC (contrÃ´le d'accÃ¨s
+au mÃ©dium), et certaines permettent le paramÃ©trage du mÃ©canisme des tentatives
+(en cas d'Ã©chec).
 .br
 Pour fixer le nombre maximum d'essais, entrez
 .IR "limit `valeur'" .
-C'est une valeur absolue (sans unité).
-Pour fixer le temps maximum autorisé au mécanisme MAC pour ses tentatives,
+C'est une valeur absolue (sans unitÃ©).
+Pour fixer le temps maximum autorisÃ© au mÃ©canisme MAC pour ses tentatives,
 entrez
 .IR "lifetime `valeur'" .
-Par défaut, cette valeur est en secondes, ajouter le suffixe m ou u pour
-spécifier les valeurs en millisecondes ou microsecondes.
+Par dÃ©faut, cette valeur est en secondes, ajouter le suffixe m ou u pour
+spÃ©cifier les valeurs en millisecondes ou microsecondes.
 .br
 Vous pouvez aussi ajouter les modificateurs
 .IR min " et " max ".
-Si la carte supporte le mode automatique, ils définissent les limites du
-lifetime, ou les limites inférieure et supérieure (NDT\ : de l'intervalle
-temporel dans lequel le mécanisme MAC est autorisé à réitérer ses tentatives).
-D'autres cartes définissent des valeurs différentes en fonction de la taille
-des paquets, par exemple la norme 802.11 définit une
+Si la carte supporte le mode automatique, ils dÃ©finissent les limites du
+lifetime, ou les limites infÃ©rieure et supÃ©rieure (NDT\ : de l'intervalle
+temporel dans lequel le mÃ©canisme MAC est autorisÃ© Ã  rÃ©itÃ©rer ses tentatives).
+D'autres cartes dÃ©finissent des valeurs diffÃ©rentes en fonction de la taille
+des paquets, par exemple la norme 802.11 dÃ©finit une
 .I min limit
-qui est la limite inférieure d'essai (paquets non RTS/CTS).
+qui est la limite infÃ©rieure d'essai (paquets non RTS/CTS).
 .br
 .B Exemples :
 .br
@@ -410,131 +410,131 @@ qui est la limite inférieure d'essai (paquets non RTS/CTS).
 .I "	iwconfig eth0 retry min limit 8"
 .TP
 .BR commit
-Certaines cartes peuvent ne pas appliquer immédiatement les changements
-effectués par les Wireless Extensions (elles peuvent attendre pour prendre en
-compte les changements ou les appliquer seulement quand la carte est montée via
-ifconfig). Cette commande (si disponible) force la carte à appliquer les
+Certaines cartes peuvent ne pas appliquer immÃ©diatement les changements
+effectuÃ©s par les Wireless Extensions (elles peuvent attendre pour prendre en
+compte les changements ou les appliquer seulement quand la carte est montÃ©e via
+ifconfig). Cette commande (si disponible) force la carte Ã  appliquer les
 changements en suspens.
 .br
-Cela n'est normalement pas nécessaire, car la carte appliquera éventuellement
-les changements, mais peut être utile pour débuggage.
+Cela n'est normalement pas nÃ©cessaire, car la carte appliquera Ã©ventuellement
+les changements, mais peut Ãªtre utile pour dÃ©buggage.
 .\"
 .\" DISPLAY part
 .\"
 .SH AFFICHAGE
-Pour chaque matériel qui supporte les extensions wireless,
+Pour chaque matÃ©riel qui supporte les extensions wireless,
 .I iwconfig
 affiche le nom du
 .B protocole MAC
-utilisé (nom du matériel pour les protocoles propriétaires),
+utilisÃ© (nom du matÃ©riel pour les protocoles propriÃ©taires),
 .RB l' ESSID
 (Network Name), le
 .BR NWID ,
 la
-.B fréquence
+.B frÃ©quence
 (ou canal), la
-.BR sensibilité ,
+.BR sensibilitÃ© ,
 le
 .B mode
 d'exploitation, l'adresse du
-.BR "Point d'Accès",
+.BR "Point d'AccÃ¨s",
 le
-.BR débit ,
+.BR dÃ©bit ,
 le
 .BR "seuil RTS" " (" "RTS threshold" "), le "
 .BR "seuil de fragmentation" " (" "fragmentation threshold" "), la
 .B clef de cryptage
-et les paramètres de
-.BR "gestion de l'énergie" " (" "power management" ")"
-(en fonction de la disponibilité).
+et les paramÃ¨tres de
+.BR "gestion de l'Ã©nergie" " (" "power management" ")"
+(en fonction de la disponibilitÃ©).
 .PP
-Les paramètres affichés ont la même signification et la même valeur que ceux
-que vous pouvez régler, veuillez vous reporter à la précédente partie pour
-leur explication détaillée.
+Les paramÃ¨tres affichÃ©s ont la mÃªme signification et la mÃªme valeur que ceux
+que vous pouvez rÃ©gler, veuillez vous reporter Ã  la prÃ©cÃ©dente partie pour
+leur explication dÃ©taillÃ©e.
 .br
-Quelques paramètres sont affichés seulement dans une forme abrégée (comme le
+Quelques paramÃ¨tres sont affichÃ©s seulement dans une forme abrÃ©gÃ©e (comme le
 cryptage). Vous devez utiliser
 .IR iwlist (8)
-pour avoir tous les détails.
+pour avoir tous les dÃ©tails.
 .br
-Certains paramètres ont deux modes (comme le débit). Si la valeur est préfixée
+Certains paramÃ¨tres ont deux modes (comme le dÃ©bit). Si la valeur est prÃ©fixÃ©e
 par
-.RB «\ =\ »,
-cela veut dire que le paramètre est fixé et forcé à cette valeur, s'il est
-préfixé par
-.RB «\ :\ »,
-le paramètre est en mode automatique et la valeur courante est montrée (et peut
+.RB Â«\ =\ Â»,
+cela veut dire que le paramÃ¨tre est fixÃ© et forcÃ© Ã  cette valeur, s'il est
+prÃ©fixÃ© par
+.RB Â«\ :\ Â»,
+le paramÃ¨tre est en mode automatique et la valeur courante est montrÃ©e (et peut
 changer).
 .TP
 .BR "Access Point" / Cell
-Une adresse égale à 00:00:00:00:00:00 signifie que la carte n'a pas réussi à
-s'associer avec un Point d'Accès (le plus souvent une question de
+Une adresse Ã©gale Ã  00:00:00:00:00:00 signifie que la carte n'a pas rÃ©ussi Ã 
+s'associer avec un Point d'AccÃ¨s (le plus souvent une question de
 configuration).
-Le paramètre
+Le paramÃ¨tre
 .B Access Point
-sera montré comme une cellule
+sera montrÃ© comme une cellule
 .RB ( Cell )
-en mode ad hoc (pour des raisons évidentes), mais il fonctionne néanmoins
-de la même manière.
+en mode ad hoc (pour des raisons Ã©videntes), mais il fonctionne nÃ©anmoins
+de la mÃªme maniÃ¨re.
 .PP
 Si
 .I /proc/net/wireless
 existe,
 .I iwconfig
-affichera aussi son contenu. Il faut noter que ces valeurs dépendent des
-spécifications du pilote et de la carte, vous devrez donc vous référez à la
-documentation du pilote pour une interprétation correcte de ces valeurs.
+affichera aussi son contenu. Il faut noter que ces valeurs dÃ©pendent des
+spÃ©cifications du pilote et de la carte, vous devrez donc vous rÃ©fÃ©rez Ã  la
+documentation du pilote pour une interprÃ©tation correcte de ces valeurs.
 .TP
 .B Link quality
-Qualité globale du lien. Peut être basé sur le niveau de contention ou des
-interférences, le taux d'erreur de trame ou de bit, la qualité du signal reçu,
-des synchronisations temporelles, ou autre métrique matérielle. C'est une valeur
-agrégat, et dépend totalement du pilote et du matériel.
+QualitÃ© globale du lien. Peut Ãªtre basÃ© sur le niveau de contention ou des
+interfÃ©rences, le taux d'erreur de trame ou de bit, la qualitÃ© du signal reÃ§u,
+des synchronisations temporelles, ou autre mÃ©trique matÃ©rielle. C'est une valeur
+agrÃ©gat, et dÃ©pend totalement du pilote et du matÃ©riel.
 .TP
 .B Signal level
-Force du signal reçu (RSSI - force du signal reçu). Cela peut être des unités
+Force du signal reÃ§u (RSSI - force du signal reÃ§u). Cela peut Ãªtre des unitÃ©s
 arbitraires ou des dBm,
 .I iwconfig
-utilise des méta-informations du pilote pour interpréter les valeurs
-brutes données par
+utilise des mÃ©ta-informations du pilote pour interprÃ©ter les valeurs
+brutes donnÃ©es par
 .I /proc/net/wireless
-et affiche l'unité ou la valeur maximale correspondante (utilise l'arithmétique
+et affiche l'unitÃ© ou la valeur maximale correspondante (utilise l'arithmÃ©tique
 8 bits). En mode
 .I Ad-Hoc
-cela peut être indéfini et vous devriez utiliser
+cela peut Ãªtre indÃ©fini et vous devriez utiliser
 .IR iwspy .
 .TP
 .B Noise level
 Niveau du bruit de fond (quand aucun paquet n'est transmis). Commentaires
-similaires à ceux de
+similaires Ã  ceux de
 .BR "Signal level" .
 .TP
 .B Rx invalid nwid
-Nombre de paquets reçus avec un NWID ou ESSID différent. Utilisé pour détecter
-des problèmes de configuration ou l'existence de réseau adjacent (sur la même
-fréquence).
+Nombre de paquets reÃ§us avec un NWID ou ESSID diffÃ©rent. UtilisÃ© pour dÃ©tecter
+des problÃ¨mes de configuration ou l'existence de rÃ©seau adjacent (sur la mÃªme
+frÃ©quence).
 .TP
 .B Rx invalid crypt
-Nombre de paquets que le matériel a été incapable de décrypter. Cela peut être
-utilisé pour détecter des mauvais paramètres de cryptage.
+Nombre de paquets que le matÃ©riel a Ã©tÃ© incapable de dÃ©crypter. Cela peut Ãªtre
+utilisÃ© pour dÃ©tecter des mauvais paramÃ¨tres de cryptage.
 .TP
 .B Rx invalid frag
-Nombre de paquets pour lesquels le matériel a été incapable de ré-assembler
+Nombre de paquets pour lesquels le matÃ©riel a Ã©tÃ© incapable de rÃ©-assembler
 correctement les fragments de la couche liaison (le plus souvent, il en manque
 un).
 .TP
 .B Tx excessive retries
-Nombre de paquets que la carte n'a pas réussi à envoyer. La plupart des
-protocoles MAC réessaient un certain nombre de fois avant d'abandonner.
+Nombre de paquets que la carte n'a pas rÃ©ussi Ã  envoyer. La plupart des
+protocoles MAC rÃ©essaient un certain nombre de fois avant d'abandonner.
 .TP
 .B invalid misc
-Autres paquets perdus en relation avec les opérations spécifiques au sans fil.
+Autres paquets perdus en relation avec les opÃ©rations spÃ©cifiques au sans fil.
 .TP
 .B Missed beacon
-Nombre de beacons périodiques émis par la Cellule ou le Point d'Accès que nous
-avons manqué. Les beacons sont envoyés à intervalles réguliers pour maintenir la
-coordination de la cellule, l'impossibilité de les recevoir indiquant souvent
-que la carte est hors de portée.
+Nombre de beacons pÃ©riodiques Ã©mis par la Cellule ou le Point d'AccÃ¨s que nous
+avons manquÃ©. Les beacons sont envoyÃ©s Ã  intervalles rÃ©guliers pour maintenir la
+coordination de la cellule, l'impossibilitÃ© de les recevoir indiquant souvent
+que la carte est hors de portÃ©e.
 .\"
 .\" AUTHOR part
 .\"
@@ -544,12 +544,12 @@ Jean Tourrilhes \- jt@hpl.hp.com
 .\" TRADUCTION part
 .\"
 .SH TRADUCTION
-Maxime CHARPENNE, août 2004 (wireless_tools.27-pre25).
+Maxime CHARPENNE, aoÃ»t 2004 (wireless_tools.27-pre25).
 .\"
 .\" AVERTISSEMENT part
 .\"
 .SH AVERTISSEMENT SUR LA TRADUCTION
-Il est possible que cette traduction soit imparfaite ou périmée. En cas de
+Il est possible que cette traduction soit imparfaite ou pÃ©rimÃ©e. En cas de
 doute, veuillez vous reporter au document original en langue anglaise fourni
 avec le programme.
 .\"

--- a/wireless_tools/fr/iwevent.8
+++ b/wireless_tools/fr/iwevent.8
@@ -3,18 +3,18 @@
 .\"
 .\" Traduction 2003/08/17 Maxime CHARPENNE (voir
 .\" http://www.delafond.org/traducmanfr/)
-.\" 1ère traduction        : version 26
+.\" 1Ã¨re traduction        : version 26
 .\" Manuel identique pour la version 27-pre9 (beta)
-.\" Mise à jour 2004/02/26 : version 27-pre11 (alpha)
-.\" Mise à jour 2004/08/23 : version 27-pre25
+.\" Mise Ã  jour 2004/02/26 : version 27-pre11 (alpha)
+.\" Mise Ã  jour 2004/08/23 : version 27-pre25
 .\"
 .TH IWEVENT 8 "23 juin 2004" "net-tools" "Manuel du Programmeur Linux"
 .\"
 .\" NAME part
 .\"
 .SH NOM
-iwevent \- Affiche les Événements Wireless (Wireless Events) générés par les
-pilotes et les changements de paramètres.
+iwevent \- Affiche les Ã‰vÃ©nements Wireless (Wireless Events) gÃ©nÃ©rÃ©s par les
+pilotes et les changements de paramÃ¨tres.
 .\"
 .\" SYNOPSIS part
 .\"
@@ -26,9 +26,9 @@ pilotes et les changements de paramètres.
 .\"
 .SH DESCRIPTION
 .B iwevent
-affiche les «\ Wireless Events\ » (événements du système Wireless) reçu par le
-socket RTNetlink. Chaque ligne affiche le Wireless Event spécifique qui décrit
-ce qui s'est passé sur l'interface sans fil spécifiée.
+affiche les Â«\ Wireless Events\ Â» (Ã©vÃ©nements du systÃ¨me Wireless) reÃ§u par le
+socket RTNetlink. Chaque ligne affiche le Wireless Event spÃ©cifique qui dÃ©crit
+ce qui s'est passÃ© sur l'interface sans fil spÃ©cifiÃ©e.
 .br
 Cette commande ne prend aucun argument.
 .\"
@@ -37,13 +37,13 @@ Cette commande ne prend aucun argument.
 .SH AFFICHAGE
 Il y a deux classes de Wireless Events.
 .PP
-La première classe regroupe les événements relatifs à un changement des
-paramètres du sans fil sur l'interface (typiquement fait par
+La premiÃ¨re classe regroupe les Ã©vÃ©nements relatifs Ã  un changement des
+paramÃ¨tres du sans fil sur l'interface (typiquement fait par
 .B iwconfig
 ou un script appelant
 .BR iwconfig ).
-Seuls les paramètres qui peuvent entraîner une perturbation de la connectivité
-sont rapportés. Les événements actuellement rapportés changent un des paramètres
+Seuls les paramÃ¨tres qui peuvent entraÃ®ner une perturbation de la connectivitÃ©
+sont rapportÃ©s. Les Ã©vÃ©nements actuellement rapportÃ©s changent un des paramÃ¨tres
 suivants\ :
 .br
 .I "	Network ID"
@@ -56,53 +56,53 @@ suivants\ :
 .br
 .I "	Encryption"
 .br
-Tous ces événements seront générer sur toutes les interfaces sans fil par le
-sous-système «\ wireless\ » du noyau (mais seulement si le pilote a été converti
-àl'API du nouveau pilote).
+Tous ces Ã©vÃ©nements seront gÃ©nÃ©rer sur toutes les interfaces sans fil par le
+sous-systÃ¨me Â«\ wireless\ Â» du noyau (mais seulement si le pilote a Ã©tÃ© converti
+Ã l'API du nouveau pilote).
 .PP
-La deuxième classe d'événements concerne ceux générés par le matériel, lorsque
-quelque chose arrive ou qu'une tâche s'est terminée. Ces événements incluent\ :
+La deuxiÃ¨me classe d'Ã©vÃ©nements concerne ceux gÃ©nÃ©rÃ©s par le matÃ©riel, lorsque
+quelque chose arrive ou qu'une tÃ¢che s'est terminÃ©e. Ces Ã©vÃ©nements incluent\ :
 .TP
 .B New Access Point/Cell address
-L'interface a joint un nouveau point d'accès ou cellule ad hoc, ou perdu son
-association avec. Il s'agit de la même adresse MAC affiché par
+L'interface a joint un nouveau point d'accÃ¨s ou cellule ad hoc, ou perdu son
+association avec. Il s'agit de la mÃªme adresse MAC affichÃ© par
 .BR iwconfig .
 .TP
 .B Scan request completed
-Une requête de balayage (scanning) a été achevée, les résultats du «\ scan\ »
+Une requÃªte de balayage (scanning) a Ã©tÃ© achevÃ©e, les rÃ©sultats du Â«\ scan\ Â»
 sont disponibles (voir
 .BR iwlist ).
 .TP
 .B Tx packet dropped
-Un paquet à destination de cette adresse a été rejeté car l'interface croit que
-ce noeud ne répond plus (habituellement, le seuil maximum des émissions de la
-couche MAC est atteint). C'est habituellement la première indication pouvant
-révéler que le noeud a quitté la cellule ou est hors de portée, mais cela peut
-être due à une atténuation ou une contention excessive.
+Un paquet Ã  destination de cette adresse a Ã©tÃ© rejetÃ© car l'interface croit que
+ce noeud ne rÃ©pond plus (habituellement, le seuil maximum des Ã©missions de la
+couche MAC est atteint). C'est habituellement la premiÃ¨re indication pouvant
+rÃ©vÃ©ler que le noeud a quittÃ© la cellule ou est hors de portÃ©e, mais cela peut
+Ãªtre due Ã  une attÃ©nuation ou une contention excessive.
 .TP
 .B Custom driver event
-Événement spécifique au pilote. Veuillez consulter la documentation du pilote.
+Ã‰vÃ©nement spÃ©cifique au pilote. Veuillez consulter la documentation du pilote.
 .TP
 .B Registered node
-L'interface a réussi à enregistrer un nouveau client/paire sans fil. Sera
-généré la plupart du temps quand l'interface agit comme un point d'accès (mode
+L'interface a rÃ©ussi Ã  enregistrer un nouveau client/paire sans fil. Sera
+gÃ©nÃ©rÃ© la plupart du temps quand l'interface agit comme un point d'accÃ¨s (mode
 master).
 .TP
 .B Expired node
-L'enregistrement d'un client/paire sur cette interface a expiré. Sera généré la
-plupart du temps quand l'interface agit comme un point d'accès (mode master).
+L'enregistrement d'un client/paire sur cette interface a expirÃ©. Sera gÃ©nÃ©rÃ© la
+plupart du temps quand l'interface agit comme un point d'accÃ¨s (mode master).
 .TP
 .B Spy threshold crossed
-La force du signal pour une des adresses de la «\ spy list\ » (NDT\ : voir
-iwspy(8)) est passé en-dessous du seuil bas, ou est passé au-dessus du seuil
+La force du signal pour une des adresses de la Â«\ spy list\ Â» (NDT\ : voir
+iwspy(8)) est passÃ© en-dessous du seuil bas, ou est passÃ© au-dessus du seuil
 haut.
 .PP
-La plupart des pilotes wireless génèrent seulement un sous-ensemble de ces
-événements, pas tous, la liste exacte dépendant de la combinaison spécifique
-matériel/pilote. Veuillez consulter la documentation du pilote pour les détails
-de ce qui les génèrent, et utilisez
+La plupart des pilotes wireless gÃ©nÃ¨rent seulement un sous-ensemble de ces
+Ã©vÃ©nements, pas tous, la liste exacte dÃ©pendant de la combinaison spÃ©cifique
+matÃ©riel/pilote. Veuillez consulter la documentation du pilote pour les dÃ©tails
+de ce qui les gÃ©nÃ¨rent, et utilisez
 .IR iwlist (8)
-pour vérifier ce que le pilote supporte.
+pour vÃ©rifier ce que le pilote supporte.
 .\"
 .\" AUTHOR part
 .\"
@@ -112,12 +112,12 @@ Jean Tourrilhes \- jt@hpl.hp.com
 .\" TRADUCTION part
 .\"
 .SH TRADUCTION
-Maxime CHARPENNE, août 2004 (wireless_tools.27-pre25).
+Maxime CHARPENNE, aoÃ»t 2004 (wireless_tools.27-pre25).
 .\"
 \" AVERTISSEMENT part
 .\"
 .SH AVERTISSEMENT SUR LA TRADUCTION
-Il est possible que cette traduction soit imparfaite ou périmée. En cas de
+Il est possible que cette traduction soit imparfaite ou pÃ©rimÃ©e. En cas de
 doute, veuillez vous reporter au document original en langue anglaise fourni
 avec le programme.
 .\"

--- a/wireless_tools/fr/iwgetid.8
+++ b/wireless_tools/fr/iwgetid.8
@@ -4,18 +4,18 @@
 .\"
 .\" Traduction 2003/08/17 Maxime CHARPENNE (voir
 .\" http://www.delafond.org/traducmanfr/)
-.\" 1ère traduction        : version 26
-.\" Mise à jour 2004/01/29 : version 27-pre9 (beta)
+.\" 1Ã¨re traduction        : version 26
+.\" Mise Ã  jour 2004/01/29 : version 27-pre9 (beta)
 .\" Manuel identique pour la version 27-pre11 (alpha)
-.\" Mise à jour 2004/08/23 : version 27-pre25
+.\" Mise Ã  jour 2004/08/23 : version 27-pre25
 .\"
-.TH IWGETID 8 "02 décembre 2003" "wireless-tools" "Manuel du Programmeur Linux"
+.TH IWGETID 8 "02 dÃ©cembre 2003" "wireless-tools" "Manuel du Programmeur Linux"
 .\"
 .\" NAME part
 .\"
 .SH NOM
-iwgetid \- Rapporte le ESSID, NWID ou l'Adresse de l'AP/Cell (Point d'Accès/\
-Cellule) du réseau sans fil.
+iwgetid \- Rapporte le ESSID, NWID ou l'Adresse de l'AP/Cell (Point d'AccÃ¨s/\
+Cellule) du rÃ©seau sans fil.
 .\"
 .\" SYNOPSIS part
 .\"
@@ -29,51 +29,51 @@ Cellule) du réseau sans fil.
 .\"
 .SH DESCRIPTION
 .B iwgetid
-est utilisé pour trouver le NWID, ESSID ou l'adresse de l'AP ou cellule du
-réseau sans fil utilisé présentement. L'information rapportée est la même
-que celle montrée par
+est utilisÃ© pour trouver le NWID, ESSID ou l'adresse de l'AP ou cellule du
+rÃ©seau sans fil utilisÃ© prÃ©sentement. L'information rapportÃ©e est la mÃªme
+que celle montrÃ©e par
 .BR iwconfig ", mais " iwgetid
-est plus facile à intégrer dans les scripts.
+est plus facile Ã  intÃ©grer dans les scripts.
 .br
-Par défaut,
+Par dÃ©faut,
 .B iwgetid
 affichera
 .RI l' ESSID
 de la carte, et si la carte n'a pas d'ESSID, il affichera son
 .IR NWID .
 .br
-Le formatage par défaut de la sortie est embelli.
+Le formatage par dÃ©faut de la sortie est embelli.
 .\"
 .\" OPTIONS part
 .\"
 .SH OPTIONS
 .TP
 .B --raw
-Cette option désactive l'embellissement de l'affichage de l'information. Cette
+Cette option dÃ©sactive l'embellissement de l'affichage de l'information. Cette
 option est orthogonale aux autres options (sauf
 .BR --scheme ),
-donc, avec la combinaison appropriée des options, il est possible d'afficher
+donc, avec la combinaison appropriÃ©e des options, il est possible d'afficher
 en brut l'ESSID, l'Adresse de l'AP ou le Mode.
 .br
-Ce format est idéal quand on stocke le résultat de iwgetid comme une variable
+Ce format est idÃ©al quand on stocke le rÃ©sultat de iwgetid comme une variable
 dans les scripts
 .I Shell
 ou
 .IR Perl ,
-ou pour passer le résultat comme argument sur la ligne de commande de
+ou pour passer le rÃ©sultat comme argument sur la ligne de commande de
 .BR iwconfig .
 .TP
 .B --scheme
-Cette option est similaire à la précédente, elle désactive l'embellissement de
-l'affichage des données et supprime tous les caractères non alphanumériques
-(comme les caractères d'espacement, la ponctuation et les caractères de
-contrôle).
+Cette option est similaire Ã  la prÃ©cÃ©dente, elle dÃ©sactive l'embellissement de
+l'affichage des donnÃ©es et supprime tous les caractÃ¨res non alphanumÃ©riques
+(comme les caractÃ¨res d'espacement, la ponctuation et les caractÃ¨res de
+contrÃ´le).
 .br
-La sortie résultante est un identifiant Pcmcia valide («\ Pcmcia scheme
-identifer\ ») (qui peut être utilisé comme argument de la commande
+La sortie rÃ©sultante est un identifiant Pcmcia valide (Â«\ Pcmcia scheme
+identifer\ Â») (qui peut Ãªtre utilisÃ© comme argument de la commande
 .BR "cardctl scheme" ).
-Ce format est aussi idéal quand on utilise le résultat de iwgetid comme un
-sélecteur («\ selector\ ») dans les scripts
+Ce format est aussi idÃ©al quand on utilise le rÃ©sultat de iwgetid comme un
+sÃ©lecteur (Â«\ selector\ Â») dans les scripts
 .I Shell
 ou
 .IR Perl ,
@@ -88,16 +88,16 @@ sans fil.
 .TP
 .B --freq
 Affiche la
-.I fréquence
+.I frÃ©quence
 ou le
 .I canal
-courant utilisé par l'interface.
+courant utilisÃ© par l'interface.
 .TP
 .B --channel
 Affiche le canal
 .RI ( channel )
-courant utilisé par l'interface. Le canal est déterminé en utilisant la
-fréquence courante et la liste de fréquence fournie par l'interface.
+courant utilisÃ© par l'interface. Le canal est dÃ©terminÃ© en utilisant la
+frÃ©quence courante et la liste de frÃ©quence fournie par l'interface.
 .TP
 .B --mode
 Affiche le
@@ -108,22 +108,22 @@ courant de l'interface.
 Affiche le
 .I nom de protocole
 de l'interface. Il permet d'identifer toutes les cartes qui sont compatibles
-entre elles et qui acceptent le même type de configuration.
+entre elles et qui acceptent le mÃªme type de configuration.
 .br
-Cela peut aussi être utilisé pour
-.I vérifier la compatibilité de Wireless Extension
+Cela peut aussi Ãªtre utilisÃ© pour
+.I vÃ©rifier la compatibilitÃ© de Wireless Extension
 sur l'interface, car c'est le seul attribut que tous les pilotes supportant
 Wireless Extension doivent avoir.
 .\"
 .\" TRADUCTION part
 .\"
 .SH TRADUCTION
-Maxime CHARPENNE, août 2004 (wireless_tools.27-pre25).
+Maxime CHARPENNE, aoÃ»t 2004 (wireless_tools.27-pre25).
 .\"
 \" AVERTISSEMENT part
 .\"
 .SH AVERTISSEMENT SUR LA TRADUCTION
-Il est possible que cette traduction soit imparfaite ou périmée. En cas de
+Il est possible que cette traduction soit imparfaite ou pÃ©rimÃ©e. En cas de
 doute, veuillez vous reporter au document original en langue anglaise fourni
 avec le programme.
 .\"

--- a/wireless_tools/fr/iwlist.8
+++ b/wireless_tools/fr/iwlist.8
@@ -3,17 +3,17 @@
 .\"
 .\" Traduction 2003/08/17 Maxime CHARPENNE (voir
 .\" http://www.delafond.org/traducmanfr/)
-.\" 1ère traduction        : version 26
-.\" Mise à jour 2004/01/29 : version 27-pre9 (beta)
+.\" 1Ã¨re traduction        : version 26
+.\" Mise Ã  jour 2004/01/29 : version 27-pre9 (beta)
 .\" Manuel identique pour la version 27-pre11 (alpha)
-.\" Mise à jour 2004/08/23 : version 27-pre25
+.\" Mise Ã  jour 2004/08/23 : version 27-pre25
 .\"
 .TH IWLIST 8 "23 juin 2004" "wireless-tools" "Manuel du Programmeur Linux"
 .\"
 .\" NAME part
 .\"
 .SH NOM
-iwlist \- Obtient plus d'informations wireless détaillées depuis une interface wireless
+iwlist \- Obtient plus d'informations wireless dÃ©taillÃ©es depuis une interface wireless
 .\"
 .\" SYNOPSIS part
 .\"
@@ -42,91 +42,91 @@ iwlist \- Obtient plus d'informations wireless détaillées depuis une interface w
 .\"
 .SH DESCRIPTION
 .B Iwlist
-est utilisé pour afficher de l'information additionnelle d'une interface réseau
-wireless qui n'est pas affichée par
+est utilisÃ© pour afficher de l'information additionnelle d'une interface rÃ©seau
+wireless qui n'est pas affichÃ©e par
 .IR iwconfig (8)
-L'argument principal est utilisé pour sélectionner une catégorie d'information,
+L'argument principal est utilisÃ© pour sÃ©lectionner une catÃ©gorie d'information,
 .B iwlist
-affiche dans une forme détaillée toute information relative à cette catégorie,
-y compris les informations déjà montrées par
+affiche dans une forme dÃ©taillÃ©e toute information relative Ã  cette catÃ©gorie,
+y compris les informations dÃ©jÃ  montrÃ©es par
 .IR iwconfig (8).
 .\"
 .\" PARAMETER part
 .\"
-.SH PARAMÈTRES
+.SH PARAMÃˆTRES
 .TP
 .BR scan [ning]
-Donne la liste des Points d'Accès et des cellules Ad-Hoc à portée, et
-optionnellement plein d'autres informations à leur propos (ESSID, Quality,
-Frequency, Mode...). Le type d'information retourné dépend de ce que la carte
+Donne la liste des Points d'AccÃ¨s et des cellules Ad-Hoc Ã  portÃ©e, et
+optionnellement plein d'autres informations Ã  leur propos (ESSID, Quality,
+Frequency, Mode...). Le type d'information retournÃ© dÃ©pend de ce que la carte
 supporte.
 .br
-Le «\ Triggering scanning\ » est une opération nécessitant les privilèges
+Le Â«\ Triggering scanning\ Â» est une opÃ©ration nÃ©cessitant les privilÃ¨ges
 de
 .I root
-et les utilisateurs normaux peuvent juste lire les résultats («\ letf-over scan
-results\ »). Par défaut, les paramètres courants du pilote auront une grande
-incidence sur la manière dont le scan est réalisé (la boucle du scan). Aussi,
-cette commande est supposée prendre des arguments supplémentaires pour contrôler
-le comportement du scan, mais cela n'est actuellement pas implémenté.
+et les utilisateurs normaux peuvent juste lire les rÃ©sultats (Â«\ letf-over scan
+results\ Â»). Par dÃ©faut, les paramÃ¨tres courants du pilote auront une grande
+incidence sur la maniÃ¨re dont le scan est rÃ©alisÃ© (la boucle du scan). Aussi,
+cette commande est supposÃ©e prendre des arguments supplÃ©mentaires pour contrÃ´ler
+le comportement du scan, mais cela n'est actuellement pas implÃ©mentÃ©.
 .TP
 .BR freq [uency]/ channel
-Donne la liste des fréquences disponibles du périphérique et le nombre de canaux
-définis. Veuillez noter que, habituellement, le pilote retourne le nombre total
-de canaux et seulement les fréquences disponibles dans la région considérée,
-donc il n'y a pas correspondance entre le nombre de fréquences affichées et le
+Donne la liste des frÃ©quences disponibles du pÃ©riphÃ©rique et le nombre de canaux
+dÃ©finis. Veuillez noter que, habituellement, le pilote retourne le nombre total
+de canaux et seulement les frÃ©quences disponibles dans la rÃ©gion considÃ©rÃ©e,
+donc il n'y a pas correspondance entre le nombre de frÃ©quences affichÃ©es et le
 nombre de canaux.
 .TP
 .BR rate / bit [rate]
-Liste les débits supportés par le périphérique (en b/s).
+Liste les dÃ©bits supportÃ©s par le pÃ©riphÃ©rique (en b/s).
 .TP
 .BR key / enc [ryption]
-Liste les tailles des clefs de cryptage supportées et affiche toutes
-les clefs de cryptage disponibles dans le périphérique.
+Liste les tailles des clefs de cryptage supportÃ©es et affiche toutes
+les clefs de cryptage disponibles dans le pÃ©riphÃ©rique.
 .TP
 .B power
-Liste les divers attributs et modes d'économie d'énergie («\ Power
-Management\ ») du périphérique.
+Liste les divers attributs et modes d'Ã©conomie d'Ã©nergie (Â«\ Power
+Management\ Â») du pÃ©riphÃ©rique.
 .TP
 .B txpower
-Liste les différentes puissances d'émission («\ Transmit Powers\ »)
-disponibles dans le périphérique.
+Liste les diffÃ©rentes puissances d'Ã©mission (Â«\ Transmit Powers\ Â»)
+disponibles dans le pÃ©riphÃ©rique.
 .TP
 .B retry
-Liste les limites des tentatives de transmissions («\ transmit retry limits\ »)
-et la durée de vie des tentatives («\ retry lifetime\ ») du périphériques
+Liste les limites des tentatives de transmissions (Â«\ transmit retry limits\ Â»)
+et la durÃ©e de vie des tentatives (Â«\ retry lifetime\ Â») du pÃ©riphÃ©riques
 (NDT\ : voir la section
 .B retry
 de iwconfig(8)).
 .TP
 .BR ap / accesspoint / peers
-Donne la liste des Points d'Accès à portée, et optionnellement la qualié de leur
+Donne la liste des Points d'AccÃ¨s Ã  portÃ©e, et optionnellement la qualiÃ© de leur
 lien. Cette option est
-.B obsolète
-et est maintenant dépréciée en faveur du support scan (voir ci-dessus), et la
+.B obsolÃ¨te
+et est maintenant dÃ©prÃ©ciÃ©e en faveur du support scan (voir ci-dessus), et la
 plupart des pilotes ne le supporte pas.
 .br
 Quelques pilotes peuvent utiliser cette commande pour retourner une
-liste spécifique de Paires («\ Peers\ ») ou de Points d'Accès, telle que la
-liste des Paires associés/enregistrés avec la carte. Voir la documentation du
-pilote pour plus de détails.
+liste spÃ©cifique de Paires (Â«\ Peers\ Â») ou de Points d'AccÃ¨s, telle que la
+liste des Paires associÃ©s/enregistrÃ©s avec la carte. Voir la documentation du
+pilote pour plus de dÃ©tails.
 .TP
 .B event
-Liste les événements wireless supportés par le périphérique.
+Liste les Ã©vÃ©nements wireless supportÃ©s par le pÃ©riphÃ©rique.
 .TP
 .B --version
-Affiche la version des outils, ainsi que la version courante et recommandée des
+Affiche la version des outils, ainsi que la version courante et recommandÃ©e des
 Wireless Extensions pour l'outil et les diverses interfaces sans fil.
 .\"
 .\" TRADUCTION part
 .\"
 .SH TRADUCTION
-Maxime CHARPENNE, août 2004 (wireless_tools.27-pre25).
+Maxime CHARPENNE, aoÃ»t 2004 (wireless_tools.27-pre25).
 .\"
 \" AVERTISSEMENT part
 .\"
 .SH AVERTISSEMENT SUR LA TRADUCTION
-Il est possible que cette traduction soit imparfaite ou périmée. En cas de
+Il est possible que cette traduction soit imparfaite ou pÃ©rimÃ©e. En cas de
 doute, veuillez vous reporter au document original en langue anglaise fourni
 avec le programme.
 .\"

--- a/wireless_tools/fr/iwpriv.8
+++ b/wireless_tools/fr/iwpriv.8
@@ -3,7 +3,7 @@
 .\"
 .\" Traduction 2003/08/17 Maxime CHARPENNE (voir
 .\" http://www.delafond.org/traducmanfr/)
-.\" 1�re traduction     : version 26
+.\" 1Ã¨re traduction     : version 26
 .\" Manuel identique pour version 27-pre9 (beta)
 .\" Manuel identique pour version 27-pre11 (alpha)
 .\"
@@ -12,7 +12,7 @@
 .\" NAME part
 .\"
 .SH NOM
-iwpriv \- configure les param�tres optionnels (priv�s) d'une interface r�seau
+iwpriv \- configure les paramÃ¨tres optionnels (privÃ©s) d'une interface rÃ©seau
 sans fil
 .\"
 .\" SYNOPSIS part
@@ -34,80 +34,80 @@ sans fil
 .\"
 .SH DESCRIPTION
 .B Iwpriv
-est l'outil � utiliser avec
+est l'outil Ã  utiliser avec
 .IR iwconfig (8).
 .B Iwpriv
-traite les param�tres et attributs sp�cifiques � chaque pilote (contrairement
-�
+traite les paramÃ¨tres et attributs spÃ©cifiques Ã  chaque pilote (contrairement
+Ã 
 .I iwconfig
-qui ne s'occupe que des g�n�riques).
+qui ne s'occupe que des gÃ©nÃ©riques).
 .PP
 Sans argument,
 .B iwpriv
-liste les commandes priv�es disponibles sur chaque interface, ainsi que les
-param�tres qu'elles requi�rent. En utilisant ces informations, l'utilisateur
-peut appliquer ces commandes particuli�res sur les interfaces sp�cifi�es.
+liste les commandes privÃ©es disponibles sur chaque interface, ainsi que les
+paramÃ¨tres qu'elles requiÃ¨rent. En utilisant ces informations, l'utilisateur
+peut appliquer ces commandes particuliÃ¨res sur les interfaces spÃ©cifiÃ©es.
 .PP
-En th�orie, la documentation de chaque pilote devrait indiquer comment utiliser
-ces commandes sp�cifiques et leurs effets.
+En thÃ©orie, la documentation de chaque pilote devrait indiquer comment utiliser
+ces commandes spÃ©cifiques et leurs effets.
 .\"
 .\" PARAMETER part
 .\"
-.SH PARAM�TRES
+.SH PARAMÃTRES
 .TP
 .IR private-command " [" private-parameters ]
-Ex�cute la
+ExÃ©cute la
 .I private-command
-(commande priv�e) sp�cifi�e sur l'interface.
+(commande privÃ©e) spÃ©cifiÃ©e sur l'interface.
 .br
-La commande peut �ventuellement prendre ou n�cessiter des arguments, et peut
-afficher de l'information. En cons�quent, les param�tres de la ligne de
-commande peuvent ou peuvent ne pas �tre n�cessaires et doivent correspondre
+La commande peut Ã©ventuellement prendre ou nÃ©cessiter des arguments, et peut
+afficher de l'information. En consÃ©quent, les paramÃ¨tres de la ligne de
+commande peuvent ou peuvent ne pas Ãªtre nÃ©cessaires et doivent correspondre
 aux besoins de la commande. La liste des commandes que
 .B iwpriv
-affiche (quand il est appel� sans param�tre) doit vous donner des indications
-sur ces param�tres.
+affiche (quand il est appelÃ© sans paramÃ¨tre) doit vous donner des indications
+sur ces paramÃ¨tres.
 .br
-Cependant, vous devriez vous reporter � la documentation du pilote du
-p�riph�rique pour utiliser les commandes correctement, ainsi que conna�tre
+Cependant, vous devriez vous reporter Ã  la documentation du pilote du
+pÃ©riphÃ©rique pour utiliser les commandes correctement, ainsi que connaÃ®tre
 leurs effets.
 .TP
 .I "private-command [I]" "[" private-parameters ]
 Idem, sauf que
 .I I
-(un entier) est pass� � la commande en tant que
+(un entier) est passÃ© Ã  la commande en tant que
 .I "Token Index"
-(indication d'index). Seules quelques commandes utiliseront ce �\ Token
-Index\ � (la plupart l'ignoreront), et la documentation du pilote devrait
-pr�ciser quand il est n�cessaire.
+(indication d'index). Seules quelques commandes utiliseront ce Â«\ Token
+Index\ Â» (la plupart l'ignoreront), et la documentation du pilote devrait
+prÃ©ciser quand il est nÃ©cessaire.
 .TP
 .BR -a / --all
-Ex�cute et affiche toutes les commandes priv�es qui ne prennent aucun argument
-(c.-�-d. en lecture seule).
+ExÃ©cute et affiche toutes les commandes privÃ©es qui ne prennent aucun argument
+(c.-Ã -d. en lecture seule).
 .TP
 .B roam
-Active ou d�sactive le �\ roaming\ �, s'il est support�. Appelle la commande
-priv�e
+Active ou dÃ©sactive le Â«\ roaming\ Â», s'il est supportÃ©. Appelle la commande
+privÃ©e
 .IR setroam .
-Trouv� dans le pilote
+TrouvÃ© dans le pilote
 .I wavelan_cs
 .TP
 .B port
-Lit ou configure le type de port. Appelle les commandes priv�es
+Lit ou configure le type de port. Appelle les commandes privÃ©es
 .IR gport_type ", " sport_type ", " get_port " ou " set_port
-trouv�es dans les pilotes
+trouvÃ©es dans les pilotes
 .IR wavelan2_cs " et " wvlan_cs .
 .\"
 .\" DISPLAY part
 .\"
 .SH AFFICHAGE
-Pour chaque mat�riel qui supporte les commandes priv�es,
+Pour chaque matÃ©riel qui supporte les commandes privÃ©es,
 .I iwpriv
-affichera la liste des commandes priv�es disponibles.
+affichera la liste des commandes privÃ©es disponibles.
 .PP
-Cela inclut le nom de la commande priv�e, le nombre d'arguments qui peuvent
-�tre entr�s et leur type, ainsi que le nombre d'arguments qui peuvent �tre
-affich�s et leur type.
+Cela inclut le nom de la commande privÃ©e, le nombre d'arguments qui peuvent
+Ãªtre entrÃ©s et leur type, ainsi que le nombre d'arguments qui peuvent Ãªtre
+affichÃ©s et leur type.
 .PP
 Par exemple, vous pouvez avoir l'affichage suivant\ :
 .br
@@ -117,8 +117,8 @@ Par exemple, vous pouvez avoir l'affichage suivant\ :
 .br
 .B "          gethisto (89F7) : set   0      & get  16 int"
 .PP
-Cela veut dire que vous pouvez fixer le seuil de qualit� et afficher un
-histogramme jusqu'� 16 valeurs avec les commandes suivantes\ :
+Cela veut dire que vous pouvez fixer le seuil de qualitÃ© et afficher un
+histogramme jusqu'Ã  16 valeurs avec les commandes suivantes\ :
 .br
 .I "  iwpriv eth0 setqualthr 20"
 .br
@@ -132,12 +132,12 @@ Jean Tourrilhes \- jt@hpl.hp.com
 .\" TRADUCTION part
 .\"
 .SH TRADUCTION
-Maxime CHARPENNE, ao�t 2003.
+Maxime CHARPENNE, aoÃ»t 2003.
 .\"
 \" AVERTISSEMENT part
 .\"
 .SH AVERTISSEMENT SUR LA TRADUCTION
-Il est possible que cette traduction soit imparfaite ou p�rim�e. En cas de
+Il est possible que cette traduction soit imparfaite ou pÃ©rimÃ©e. En cas de
 doute, veuillez vous reporter au document original en langue anglaise fourni
 avec le programme.
 .\"

--- a/wireless_tools/fr/iwspy.8
+++ b/wireless_tools/fr/iwspy.8
@@ -3,7 +3,7 @@
 .\"
 .\" Traduction 2003/08/18 Maxime CHARPENNE (voir
 .\" http://www.delafond.org/traducmanfr/)
-.\" 1ère traduction        : version 26
+.\" 1Ã¨re traduction        : version 26
 .\" Manuel identique pour la version 27-pre9 (beta)
 .\" Manuel identique pour la version 27-pre11 (alpha)
 .\"
@@ -12,7 +12,7 @@
 .\" NAME part
 .\"
 .SH NOM
-iwspy \- Obtenir des statistiques wireless depuis des n½uds donnés
+iwspy \- Obtenir des statistiques wireless depuis des nÂ½uds donnÃ©s
 .\"
 .\" SYNOPSIS part
 .\"
@@ -31,72 +31,72 @@ iwspy \- Obtenir des statistiques wireless depuis des n½uds donnés
 .\"
 .SH DESCRIPTION
 .B Iwspy
-est utilisé pour fixer une liste d'adresses sur une interface réseau sans fil,
-et obtenir des informations sur la qualité du lien pour chacune d'elles. Ces
-informations sont les mêmes que celles disponibles dans
+est utilisÃ© pour fixer une liste d'adresses sur une interface rÃ©seau sans fil,
+et obtenir des informations sur la qualitÃ© du lien pour chacune d'elles. Ces
+informations sont les mÃªmes que celles disponibles dans
 .IR /proc/net/wireless "\ :"
-qualité du lien, force du signal et niveau du bruit.
+qualitÃ© du lien, force du signal et niveau du bruit.
 .PP
-Ces informations sont mises à jour à chaque fois qu'un nouveau paquet est reçu,
-donc chaque adresse de la liste ajoute quelques précisions en plus.
+Ces informations sont mises Ã  jour Ã  chaque fois qu'un nouveau paquet est reÃ§u,
+donc chaque adresse de la liste ajoute quelques prÃ©cisions en plus.
 .PP
-Remarquez que cette fonctionnalité ne marche que pour les n½uds faisant partie
+Remarquez que cette fonctionnalitÃ© ne marche que pour les nÂ½uds faisant partie
 des cellules sans fil courantes.
 .\"
 .\" PARAMETER part
 .\"
-.SH PARAMÈTRES
-Vous pouvez fixer jusqu'à 8 adresses.
+.SH PARAMÃˆTRES
+Vous pouvez fixer jusqu'Ã  8 adresses.
 .TP
 .BR DNSNAME " | " IPADDR
-Paramètre une adresse IP, ou dans certains cas un nom DNS (en utilisant le
-Â«\ resolver\ Â» de nom). Comme le matériel fonctionne avec des adresses
-matérielles,
+ParamÃ¨tre une adresse IP, ou dans certains cas un nom DNS (en utilisant le
+Ã‚Â«\ resolver\ Ã‚Â» de nom). Comme le matÃ©riel fonctionne avec des adresses
+matÃ©rielles,
 .B iwspy
-traduira les adresses IP grâce à
+traduira les adresses IP grÃ¢ce Ã 
 .IR ARP .
-Dans certains cas, cette adresse peut ne pas être dans le cache ARP et
+Dans certains cas, cette adresse peut ne pas Ãªtre dans le cache ARP et
 .B iwspy
-échouera. Dans cette situation, exécuter
+Ã©chouera. Dans cette situation, exÃ©cuter
 .IR ping (8)
-vers ces noms/adresses et réessayer.
+vers ces noms/adresses et rÃ©essayer.
 .TP
 .B HWADDR
-Paramètre une adresse matérielle (MAC) (cette adresse n'est pas traduite et
-vérifer comme le sont les adresses IP). L'adresse doit contenir deux-points
+ParamÃ¨tre une adresse matÃ©rielle (MAC) (cette adresse n'est pas traduite et
+vÃ©rifer comme le sont les adresses IP). L'adresse doit contenir deux-points
 .RB ( : )
-pour être reconnue comme une adresse matérielle.
+pour Ãªtre reconnue comme une adresse matÃ©rielle.
 .TP
 .B +
-Ajoute un nouveau jeu d'adresses à la fin de la liste courante au lieu de la
+Ajoute un nouveau jeu d'adresses Ã  la fin de la liste courante au lieu de la
 remplacer. La liste d'adresses est unique pour chaque carte, donc chaque
-utilisateur devrait utiliser cette option pour éviter les conflits.
+utilisateur devrait utiliser cette option pour Ã©viter les conflits.
 .TP
 .B off
-Enlève la liste d'adresses courante et désactive la fonctionnalité de
+EnlÃ¨ve la liste d'adresses courante et dÃ©sactive la fonctionnalitÃ© de
 scrutation.
 .TP
 .B setthr
 Fixe les seuils de force de signal
 .IR low " (bas) et " high " (haut)"
-pour les événements iwspy (pour les pilotes qui le supportent).
+pour les Ã©vÃ©nements iwspy (pour les pilotes qui le supportent).
 .br
-Chaque fois que la force du signal, pour une des adresses contrôlées avec
+Chaque fois que la force du signal, pour une des adresses contrÃ´lÃ©es avec
 iwspy, passe au-dessous du seuil bas ou au-dessus du seuil haut, un Wireless
-Event est généré.
+Event est gÃ©nÃ©rÃ©.
 .br
-Ceci peut être utilisé pour surveiller la qualité du lien sans avoir à lancer
-iwspy périodiquement.
+Ceci peut Ãªtre utilisÃ© pour surveiller la qualitÃ© du lien sans avoir Ã  lancer
+iwspy pÃ©riodiquement.
 .TP
 .B getthr
-Récupère les seuils
+RÃ©cupÃ¨re les seuils
 .IR low " (bas) et " high " (haut)"
-de la force du signal pour l'événement iwspy.
+de la force du signal pour l'Ã©vÃ©nement iwspy.
 .\"
 \" AVERTISSEMENT part
 .\"
 .SH AVERTISSEMENT SUR LA TRADUCTION
-Il est possible que cette traduction soit imparfaite ou périmée. En cas de
+Il est possible que cette traduction soit imparfaite ou pÃ©rimÃ©e. En cas de
 doute, veuillez vous reporter au document original en langue anglaise fourni
 avec le programme.
 \"

--- a/wireless_tools/fr/wireless.7
+++ b/wireless_tools/fr/wireless.7
@@ -3,8 +3,8 @@
 .\"
 .\" Traduction 2004/02/26 Maxime CHARPENNE (voir
 .\" http://www.delafond.org/traducmanfr/)
-.\" 1ère traduction        : version 27-pre11 (alpha)
-.\" Mise à jour 2004/08/24 : version 27-pre25
+.\" 1Ã¨re traduction        : version 27-pre11 (alpha)
+.\" Mise Ã  jour 2004/08/24 : version 27-pre25
 .TH WIRELESS 7 "04 mars 2004" "wireless-tools" "Manuel du Programmeur Linux"
 .\"
 .\" NAME part
@@ -25,29 +25,29 @@ wireless \- Wireless Tools et Wireless Extensions
 .SH DESCRIPTION
 Les
 .B Wireless Extensions
-sont une API vous permettant de manipuler les interfaces réseaux Wireless LAN.
-Ils sont composés d'une gamme d'outils et de fichiers de configuration. Ils sont
-plus amplement détaillés dans le Linux Wireless LAN Howto.
+sont une API vous permettant de manipuler les interfaces rÃ©seaux Wireless LAN.
+Ils sont composÃ©s d'une gamme d'outils et de fichiers de configuration. Ils sont
+plus amplement dÃ©taillÃ©s dans le Linux Wireless LAN Howto.
 .br
 Les
 .B Wireless Tools
-sont utilisés pour changer la configuration des interfaces réseau LAN wireless
-à la volée, pour obtenir leur configuration courante, pour avoir des
-statistiques et pour les diagnostiquer. Ils sont décrits dans leur propre page
-man, voir ci-dessous pour les références.
+sont utilisÃ©s pour changer la configuration des interfaces rÃ©seau LAN wireless
+Ã  la volÃ©e, pour obtenir leur configuration courante, pour avoir des
+statistiques et pour les diagnostiquer. Ils sont dÃ©crits dans leur propre page
+man, voir ci-dessous pour les rÃ©fÃ©rences.
 .br
 La
 .B configuration Wireless
-est propre à chaque distribution Linux. Cette page man contiendra à l'avenir
-la procédure de configuration pour quelques distributions les plus communes.
-(quand j'en ai les informations nécessaires). Pour le moment, consultez le
+est propre Ã  chaque distribution Linux. Cette page man contiendra Ã  l'avenir
+la procÃ©dure de configuration pour quelques distributions les plus communes.
+(quand j'en ai les informations nÃ©cessaires). Pour le moment, consultez le
 fichier DISTRIBUTIONS.txt inclus avec le paquetage Wireless Tools.
 .\"
 .\" DEBIAN 3.0 part
 .\"
 .SH DEBIAN 3.0
-Dans la Debian 3.0 (et suivante) vous pouvez configurer les périphériques
-réseaux LAN wireless en utilisant l'outil de configuration réseau
+Dans la Debian 3.0 (et suivante) vous pouvez configurer les pÃ©riphÃ©riques
+rÃ©seaux LAN wireless en utilisant l'outil de configuration rÃ©seau
 .BR ifupdown (8).
 .TP
 .B Fichier :
@@ -68,8 +68,8 @@ wireless\-mode Ad\-Hoc
 .\" SuSE 8.0 part
 .\"
 .SH SuSE 8.0
-La SuSE 8.0 (et suivante) a intégré la configuration wireless dans ses
-scripts réseaux.
+La SuSE 8.0 (et suivante) a intÃ©grÃ© la configuration wireless dans ses
+scripts rÃ©seaux.
 .TP
 .B Outils :
 .B Yast2
@@ -95,7 +95,7 @@ info scpm
 .\"
 .SH SCRIPTS ORIGINAUX PCMCIA
 Si vous utilisez les scripts originaux de configuration du paquetage Pcmcia,
-vous pouvez utiliser cette méthode.
+vous pouvez utiliser cette mÃ©thode.
 .TP
 .B Fichier :
 .I /etc/pcmcia/wireless.opts
@@ -126,12 +126,12 @@ Jean Tourrilhes \- jt@hpl.hp.com
 .\" TRADUCTION part
 .\"
 .SH TRADUCTION
-Maxime CHARPENNE, août 2004 (wireless-tools.27-pre25).
+Maxime CHARPENNE, aoÃ»t 2004 (wireless-tools.27-pre25).
 .\"
 .\" AVERTISSEMENT part
 .\"
 .SH AVERTISSEMENT SUR LA TRADUCTION
-Il est possible que cette traduction soit imparfaite ou périmée. En cas de
+Il est possible que cette traduction soit imparfaite ou pÃ©rimÃ©e. En cas de
 doute, veuillez vous reporter au document original en langue anglaise fourni
 avec le programme.
 .\"

--- a/wireless_tools/ifrename.c
+++ b/wireless_tools/ifrename.c
@@ -18,7 +18,7 @@
  * Original CopyRight of version of 'nameif' I used is :
  * -------------------------------------------------------
  * Name Interfaces based on MAC address.
- * Writen 2000 by Andi Kleen.
+ * Written 2000 by Andi Kleen.
  * Subject to the Gnu Public License, version 2.  
  * TODO: make it support token ring etc.
  * $Id: nameif.c,v 1.3 2003/03/06 23:26:52 ecki Exp $
@@ -87,7 +87,7 @@ const int SELECT_PREVNAME	= 13;	/* Select by previous interface name */
 
 #define HAS_MAC_EXACT	1
 #define HAS_MAC_FILTER	2
-#define MAX_MAC_LEN	16	/* Maximum lenght of MAC address */
+#define MAX_MAC_LEN	16	/* Maximum length of MAC address */
 
 const struct ether_addr	zero_mac = {{ 0x00, 0x00, 0x00, 0x00, 0x00, 0x00}};
 
@@ -1785,7 +1785,7 @@ mapping_getsysfs(int			skfd,
 		      /* This may fail, but it's not fatal */
 		      fchdir(cwd_fd);
 		    }
-		  /* Check if we suceeded */
+		  /* Check if we succeeded */
 		  if(!linkpath)
 		    {
 		      free(linkpath);
@@ -2700,7 +2700,7 @@ main(int	argc,
     }
   else
     {
-      /* Load all the necesary modules */
+      /* Load all the necessary modules */
       if(use_probe)
 	{
 	  if(is_debian)

--- a/wireless_tools/iwconfig.8
+++ b/wireless_tools/iwconfig.8
@@ -452,7 +452,7 @@ The list of available modulations depend on the card/driver and can be
 displayed using
 .IR "iwlist modulation" .
 Note that some card/driver may not be able to select each modulation
-listed independantly, some may come as a group. You may also set this
+listed independently, some may come as a group. You may also set this
 parameter to
 .IR auto
 let the card/driver do its best.

--- a/wireless_tools/iwconfig.c
+++ b/wireless_tools/iwconfig.c
@@ -550,7 +550,7 @@ static const struct iwconfig_modifier	iwmod_retry[] = {
 /*
  * Parse command line modifiers.
  * Return error or number arg parsed.
- * Modifiers must be at the beggining of command line.
+ * Modifiers must be at the beginning of command line.
  */
 static int
 parse_modifiers(char *		args[],		/* Command line args */
@@ -1871,7 +1871,7 @@ set_info(int		skfd,		/* The socket */
 	  return(ret);
 	}
 
-      /* Substract consumed args from command line */
+      /* Subtract consumed args from command line */
       args += ret;
       count -= ret;
 

--- a/wireless_tools/iwgetid.c
+++ b/wireless_tools/iwgetid.c
@@ -33,7 +33,7 @@
  *
  *	This can also be integrated int he Pcmcia scripts.
  *	Some drivers don't activate the card up to "ifconfig up".
- * Therefore, they wont scan ESSID up to this point, so we can't
+ * Therefore, they won't scan ESSID up to this point, so we can't
  * read it reliably in Pcmcia scripts.
  *	I guess the proper way to write the network script is as follows :
  *			if($scheme == "iwgetid") {

--- a/wireless_tools/iwlib.c
+++ b/wireless_tools/iwlib.c
@@ -510,7 +510,7 @@ iw_get_range_info(int		skfd,
       memcpy((char *) range,
 	     buffer,
 	     iwr15_off(num_channels));
-      /* Frequencies pushed futher down towards the end */
+      /* Frequencies pushed further down towards the end */
       memcpy((char *) range + iwr_off(num_channels),
 	     buffer + iwr15_off(num_channels),
 	     iwr15_off(sensitivity) - iwr15_off(num_channels));
@@ -541,7 +541,7 @@ iw_get_range_info(int		skfd,
     }
 
   /* We are now checking much less than we used to do, because we can
-   * accomodate more WE version. But, there are still cases where things
+   * accommodate more WE version. But, there are still cases where things
    * will break... */
   if(!iw_ignore_version)
     {

--- a/wireless_tools/iwlib.h
+++ b/wireless_tools/iwlib.h
@@ -57,7 +57,7 @@
 #include <sys/socket.h>			/* for "struct sockaddr" et al	*/
 #include <net/if.h>			/* for IFNAMSIZ and co... */
 
-/* Private copy of Wireless extensions (in this directoty) */
+/* Private copy of Wireless extensions (in this directory) */
 #include "wireless.h"
 
 /* Make gcc understant that when we say inline, we mean it.
@@ -112,7 +112,7 @@ extern "C" {
 #define PROC_NET_WIRELESS	"/proc/net/wireless"
 #define PROC_NET_DEV		"/proc/net/dev"
 
-/* Some usefull constants */
+/* Some useful constants */
 #define KILO	1e3
 #define MEGA	1e6
 #define GIGA	1e9
@@ -138,7 +138,7 @@ extern "C" {
 
 struct iw_pk_event
 {
-	__u16		len;			/* Real lenght of this stuff */
+	__u16		len;			/* Real length of this stuff */
 	__u16		cmd;			/* Wireless IOCTL */
 	union iwreq_data	u;		/* IOCTL fixed payload */
 } __attribute__ ((packed));
@@ -488,7 +488,7 @@ extern const char * const	iw_operation_mode[];
 extern const struct iw_modul_descr	iw_modul_list[];
 #define IW_SIZE_MODUL_LIST	16
 
-/************************* INLINE FUNTIONS *************************/
+/************************* INLINE FUNCTIONS *************************/
 /*
  * Functions that are so simple that it's more efficient inlining them
  */

--- a/wireless_tools/iwlist.8
+++ b/wireless_tools/iwlist.8
@@ -66,7 +66,7 @@ the card supports.
 Triggering scanning is a privileged operation
 .RI ( root
 only) and normal users can only read left-over scan results. By
-default, the way scanning is done (the scope of the scan) is dependant
+default, the way scanning is done (the scope of the scan) is dependent
 on the card and card settings.
 .br
 This command take optional arguments, however most drivers will ignore

--- a/wireless_tools/iwlist.c
+++ b/wireless_tools/iwlist.c
@@ -440,7 +440,7 @@ iw_print_gen_ie(unsigned char *	buffer,
  * Note that we don't use the scanning capability of iwlib (functions
  * iw_process_scan() and iw_scan()). The main reason is that
  * iw_process_scan() return only a subset of the scan data to the caller,
- * for example custom elements and bitrates are ommited. Here, we
+ * for example custom elements and bitrates are omitted. Here, we
  * do the complete job...
  */
 

--- a/wireless_tools/wireless.10.h
+++ b/wireless_tools/wireless.10.h
@@ -153,7 +153,7 @@
  * The "flags" member indicate if the ESSID is active or not (promiscuous).
  */
 
-/* Other parameters usefull in 802.11 and some other devices */
+/* Other parameters useful in 802.11 and some other devices */
 #define SIOCSIWRATE	0x8B20		/* set default bit rate (bps) */
 #define SIOCGIWRATE	0x8B21		/* get default bit rate (bps) */
 #define SIOCSIWRTS	0x8B22		/* set RTS/CTS threshold (bytes) */

--- a/wireless_tools/wireless.11.h
+++ b/wireless_tools/wireless.11.h
@@ -158,7 +158,7 @@
  * The "flags" member indicate if the ESSID is active or not (promiscuous).
  */
 
-/* Other parameters usefull in 802.11 and some other devices */
+/* Other parameters useful in 802.11 and some other devices */
 #define SIOCSIWRATE	0x8B20		/* set default bit rate (bps) */
 #define SIOCGIWRATE	0x8B21		/* get default bit rate (bps) */
 #define SIOCSIWRTS	0x8B22		/* set RTS/CTS threshold (bytes) */

--- a/wireless_tools/wireless.14.h
+++ b/wireless_tools/wireless.14.h
@@ -647,7 +647,7 @@ struct	iw_priv_args
  */
 struct iw_event
 {
-	__u16		len;			/* Real lenght of this stuff */
+	__u16		len;			/* Real length of this stuff */
 	__u16		cmd;			/* Wireless IOCTL */
 	union iwreq_data	u;		/* IOCTL fixed payload */
 };

--- a/wireless_tools/wireless.15.h
+++ b/wireless_tools/wireless.15.h
@@ -676,7 +676,7 @@ struct	iw_priv_args
  */
 struct iw_event
 {
-	__u16		len;			/* Real lenght of this stuff */
+	__u16		len;			/* Real length of this stuff */
 	__u16		cmd;			/* Wireless IOCTL */
 	union iwreq_data	u;		/* IOCTL fixed payload */
 };

--- a/wireless_tools/wireless.16.h
+++ b/wireless_tools/wireless.16.h
@@ -711,7 +711,7 @@ struct	iw_priv_args
  */
 struct iw_event
 {
-	__u16		len;			/* Real lenght of this stuff */
+	__u16		len;			/* Real length of this stuff */
 	__u16		cmd;			/* Wireless IOCTL */
 	union iwreq_data	u;		/* IOCTL fixed payload */
 };

--- a/wireless_tools/wireless.17.h
+++ b/wireless_tools/wireless.17.h
@@ -751,7 +751,7 @@ struct	iw_priv_args
  */
 struct iw_event
 {
-	__u16		len;			/* Real lenght of this stuff */
+	__u16		len;			/* Real length of this stuff */
 	__u16		cmd;			/* Wireless IOCTL */
 	union iwreq_data	u;		/* IOCTL fixed payload */
 };

--- a/wireless_tools/wireless.18.h
+++ b/wireless_tools/wireless.18.h
@@ -1028,7 +1028,7 @@ struct	iw_priv_args
  */
 struct iw_event
 {
-	__u16		len;			/* Real lenght of this stuff */
+	__u16		len;			/* Real length of this stuff */
 	__u16		cmd;			/* Wireless IOCTL */
 	union iwreq_data	u;		/* IOCTL fixed payload */
 };

--- a/wireless_tools/wireless.19.h
+++ b/wireless_tools/wireless.19.h
@@ -1043,7 +1043,7 @@ struct	iw_priv_args
  */
 struct iw_event
 {
-	__u16		len;			/* Real lenght of this stuff */
+	__u16		len;			/* Real length of this stuff */
 	__u16		cmd;			/* Wireless IOCTL */
 	union iwreq_data	u;		/* IOCTL fixed payload */
 };

--- a/wireless_tools/wireless.20.h
+++ b/wireless_tools/wireless.20.h
@@ -1047,7 +1047,7 @@ struct	iw_priv_args
  */
 struct iw_event
 {
-	__u16		len;			/* Real lenght of this stuff */
+	__u16		len;			/* Real length of this stuff */
 	__u16		cmd;			/* Wireless IOCTL */
 	union iwreq_data	u;		/* IOCTL fixed payload */
 };

--- a/wireless_tools/wireless.21.h
+++ b/wireless_tools/wireless.21.h
@@ -1094,7 +1094,7 @@ struct	iw_priv_args
  */
 struct iw_event
 {
-	__u16		len;			/* Real lenght of this stuff */
+	__u16		len;			/* Real length of this stuff */
 	__u16		cmd;			/* Wireless IOCTL */
 	union iwreq_data	u;		/* IOCTL fixed payload */
 };

--- a/wireless_tools/wireless.22.h
+++ b/wireless_tools/wireless.22.h
@@ -1102,7 +1102,7 @@ struct	iw_priv_args
  */
 struct iw_event
 {
-	__u16		len;			/* Real lenght of this stuff */
+	__u16		len;			/* Real length of this stuff */
 	__u16		cmd;			/* Wireless IOCTL */
 	union iwreq_data	u;		/* IOCTL fixed payload */
 };


### PR DESCRIPTION
This branch converts all the source to UTF-8, and fixes common English orthographic mistakes.  No functional changes, just a cleanup.