### PR TITLE
fixed txpower flags inheriting junk memory from essid request

### DIFF
--- a/wireless_tools/iwconfig.c
+++ b/wireless_tools/iwconfig.c
@@ -108,7 +108,9 @@ get_info(int			skfd,
 
   if((info->has_range) && (info->range.we_version_compiled > 9))
     {
-      /* Get Transmit Power */
+      /* Get Transmit Power 
+       * Clear txpower flags first */
+      wrq.u.txpower.flags = 0;
       if(iw_get_ext(skfd, ifname, SIOCGIWTXPOW, &wrq) >= 0)
 	{
 	  info->has_txpower = 1;


### PR DESCRIPTION
Tx-Power does not display on PowerPC 64 Bit systems due to the flags field of the txpower Iw_Param inheriting the last two bytes of the pointer to the ESSID. Since PPC64 is Big Endian, those two bytes are filled with address data and thus cause ioctl to return EINVAL when the txpower request is made.  

This bug (#7 ) is easily fixed by simply clearing the txpower flags before requesting the txpower.
I tested this on a PPC64 system, 32 bit PPC system, and an x86_64 bit system.