### PR TITLE
Remove bzero

### DIFF
--- a/README.md
+++ b/README.md
@@ -2,4 +2,4 @@
 
 https://hewlettpackard.github.io/wireless-tools/Tools.html
 
-Migration of website, documentation, and code originally hosted at http://www.hpl.hp.com/personal/Jean_Tourrilhes/Linux/Tools.html
+Migration of website, documentation, and code originally maintained by [@jean2](https://github.com/jean2) at http://www.hpl.hp.com/personal/Jean_Tourrilhes/Linux/Tools.html

--- a/wireless_tools/ifrename.c
+++ b/wireless_tools/ifrename.c
@@ -538,7 +538,7 @@ if_takeover_name(int			skfd,
 	    victimname, autoname);
 
   /* Prepare request */
-  bzero(&ifr, sizeof(struct ifreq));
+  memset(&ifr, 0, sizeof(struct ifreq));
   strncpy(ifr.ifr_name, victimname, IFNAMSIZ); 
   strncpy(ifr.ifr_newname, autoname, IFNAMSIZ); 
 
@@ -584,7 +584,7 @@ if_set_name(int			skfd,
     }
 
   /* Prepare request */
-  bzero(&ifr, sizeof(struct ifreq));
+  memset(&ifr, 0, sizeof(struct ifreq));
   strncpy(ifr.ifr_name, oldname, IFNAMSIZ); 
   strncpy(ifr.ifr_newname, newname, IFNAMSIZ); 
 
@@ -744,7 +744,7 @@ mapping_getmac(int			skfd,
   int		i;
 
   /* Get MAC address */
-  bzero(&ifr, sizeof(struct ifreq));
+  memset(&ifr, 0, sizeof(struct ifreq));
   strncpy(ifr.ifr_name, ifname, IFNAMSIZ);
   ret = ioctl(skfd, SIOCGIFHWADDR, &ifr);
   if(ret < 0)
@@ -1037,8 +1037,8 @@ mapping_getdriverbusinfo(int			skfd,
     return(0);
 
   /* Prepare request */
-  bzero(&ifr, sizeof(struct ifreq));
-  bzero(&drvinfo, sizeof(struct ethtool_drvinfo));
+  memset(&ifr, 0, sizeof(struct ifreq));
+  memset(&drvinfo, 0, sizeof(struct ethtool_drvinfo));
   strncpy(ifr.ifr_name, ifname, IFNAMSIZ);
   drvinfo.cmd = ETHTOOL_GDRVINFO;
   ifr.ifr_data = (caddr_t) &drvinfo;
@@ -1203,8 +1203,8 @@ mapping_getbaseaddrirq(int			skfd,
     return(0);
 
   /* Prepare request */
-  bzero(&ifr, sizeof(struct ifreq));
-  bzero(&map, sizeof(struct ifmap));
+  memset(&ifr, 0, sizeof(struct ifreq));
+  memset(&map, 0, sizeof(struct ifmap));
   strncpy(ifr.ifr_name, ifname, IFNAMSIZ);
 
   /* Do it */
@@ -2047,7 +2047,7 @@ mapping_readfile(const char *	filename)
   struct add_extra	extrainfo;
 
   /* Reset the list of filters */
-  bzero(selector_active, sizeof(selector_active));
+  memset(selector_active, 0, sizeof(selector_active));
 
   /* Check filename */
   if(!strcmp(filename, "-"))

--- a/wireless_tools/iwlib.c
+++ b/wireless_tools/iwlib.c
@@ -475,7 +475,7 @@ iw_get_range_info(int		skfd,
   union iw_range_raw *	range_raw;
 
   /* Cleanup */
-  bzero(buffer, sizeof(buffer));
+  memset(buffer, 0, sizeof(buffer));
 
   wrq.u.data.pointer = (caddr_t) buffer;
   wrq.u.data.length = sizeof(buffer);
@@ -504,7 +504,7 @@ iw_get_range_info(int		skfd,
   else
     {
       /* Zero unknown fields */
-      bzero((char *) range, sizeof(struct iw_range));
+      memset((char *) range, 0, sizeof(struct iw_range));
 
       /* Initial part unmoved */
       memcpy((char *) range,
@@ -2023,7 +2023,7 @@ iw_get_mac_addr(int			skfd,
   int		ret;
 
   /* Prepare request */
-  bzero(&ifr, sizeof(struct ifreq));
+  memset(&ifr, 0, sizeof(struct ifreq));
   strncpy(ifr.ifr_name, ifname, IFNAMSIZ);
 
   /* Do it */
@@ -2960,7 +2960,7 @@ iw_process_scanning_token(struct iw_event *		event,
 	oldwscan->next = wscan;
 
       /* Reset it */
-      bzero(wscan, sizeof(struct wireless_scan));
+      memset(wscan, 0, sizeof(struct wireless_scan));
 
       /* Save cell identifier */
       wscan->has_ap_addr = 1;


### PR DESCRIPTION
Switch deprecated bzero() to memset().
This fixes build with musl libc.
Backported from Buildroot https://git.busybox.net/buildroot/tree/package/wireless_tools/0001-remove-bzero.patch